### PR TITLE
🎨 Palette: Improved keyboard accessibility and ARIA labels

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-04 - Keyboard Accessibility for Custom Inputs
+**Learning:** `display: none` on form inputs removes them from the accessibility tree, making custom toggles/switches unreachable for keyboard users.
+**Action:** Use a `.visually-hidden` utility class (opacity: 0, absolute position) to hide the native input while keeping it focusable, and use `:focus-visible` + adjacent sibling selector to style the custom control.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,13 @@
 
 > **CRITICAL**: Add entry here BEFORE every commit.
 
+### 2026-02-04
+
+- **feat**: Improved accessibility by adding focus styles for custom toggles and global focus indicators.
+- **fix**: Added ARIA labels to workflow builder buttons.
+- **Files**: `static/style.css`, `static/script.js`
+- **Verification**: Playwright script verified focus states and ARIA labels.
+
 ### 2026-02-03
 
 - **fix**: Fixed workflow password remover bug - arguments to `remove_pdf_password` were passed in wrong order (password and output_dir were swapped)

--- a/static/script.js
+++ b/static/script.js
@@ -763,8 +763,8 @@ function renderWorkflowSteps() {
         stepCard.innerHTML = `
             <i class="fas ${step.icon}"></i>
             <span class="step-label">${step.label}</span>
-            ${needsConfig(step.type) ? `<button class="config-btn" onclick="openConfigModal(${index})"><i class="fas fa-cog"></i></button>` : ''}
-            <button class="remove-step" onclick="removeStep(${index})"><i class="fas fa-times"></i></button>
+            ${needsConfig(step.type) ? `<button class="config-btn" onclick="openConfigModal(${index})" aria-label="Configure ${step.label}"><i class="fas fa-cog"></i></button>` : ''}
+            <button class="remove-step" onclick="removeStep(${index})" aria-label="Remove ${step.label}"><i class="fas fa-times"></i></button>
         `;
         container.appendChild(stepCard);
     });

--- a/static/style.css
+++ b/static/style.css
@@ -30,6 +30,24 @@ body {
     align-items: center;
 }
 
+/* Global Focus Styles for Accessibility */
+:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+}
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 /* Background Blobs */
 .background-blobs {
     position: fixed;
@@ -418,7 +436,21 @@ body {
 }
 
 .toggle-control input {
-    display: none;
+    /* Visually hidden but accessible */
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.toggle-control input:focus-visible + .control {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
 }
 
 .toggle-control .control {
@@ -522,7 +554,23 @@ body {
 }
 
 .switch-toggle input {
-    display: none;
+    /* Visually hidden but accessible */
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.switch-toggle input:focus-visible + label {
+    z-index: 2;
+    outline: 2px solid var(--primary);
+    outline-offset: -2px;
+    border-radius: 16px;
 }
 
 .switch-toggle label {


### PR DESCRIPTION
Improved keyboard accessibility and screen reader support.
1. Replaced `display: none` on custom checkboxes with a visually hidden pattern to ensure they remain in the accessibility tree and are focusable.
2. Added visual focus indicators for these custom controls.
3. Added a global focus ring for all interactive elements.
4. Added descriptive `aria-label` attributes to icon-only buttons in the Workflow Builder.
5. Recorded accessibility learnings in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [3149627354891475923](https://jules.google.com/task/3149627354891475923) started by @BhurkeSiddhesh*