### PR TITLE
🎨 Palette: Click-to-Add for Workflow Steps

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-03 - Drag-and-Drop Accessibility
+**Learning:** Drag-and-drop interfaces are inherently inaccessible to keyboard-only users.
+**Action:** Always implement a click-to-add alternative for draggable items. Ensure these items have `role="button"`, `tabindex="0"`, and explicit keyboard event handlers (or rely on a robust global handler). Visual feedback (animations) is critical to confirm the "add" action when it happens instantly via click.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,16 @@
 
 > **CRITICAL**: Add entry here BEFORE every commit.
 
+### 2026-02-03 (Palette)
+
+- **feat**: Added click-to-add support for workflow builder steps to improve accessibility for keyboard users.
+- **fix**: Added keyboard accessibility attributes (`role="button"`, `tabindex="0"`) to workflow step items.
+- **fix**: Added explicit `keydown` handler to workflow steps to prevent conflicts and ensure robust keyboard interaction.
+- **fix**: Added `aria-live` region to workflow container for screen reader feedback.
+- **style**: Added `:focus-visible` styles to workflow steps for better focus indication.
+- **Files**: `static/index.html`, `static/script.js`, `static/style.css`, `.Jules/palette.md`
+- **Verification**: Playwright verification (`verify_workflow_v2.py`) and manual keyboard testing.
+
 ### 2026-02-03
 
 - **chore**: Updated `agency.yaml` with detailed, natural language descriptions for specialized agent roles (Architect, PDF/Image Specialists, Frontend, QA/Watchdog, Workflow Orchestrator).

--- a/static/index.html
+++ b/static/index.html
@@ -312,22 +312,26 @@
                         <h3>2. Available Steps</h3>
                         <div class="step-palette">
                             <div class="step-item" draggable="true" data-step-type="remove_password"
-                                data-step-label="Unlock PDF" data-step-icon="fa-unlock">
+                                data-step-label="Unlock PDF" data-step-icon="fa-unlock" role="button" tabindex="0"
+                                aria-label="Add Unlock PDF step to workflow">
                                 <i class="fas fa-unlock"></i>
                                 <span>Unlock PDF</span>
                             </div>
                             <div class="step-item" draggable="true" data-step-type="pdf_to_word"
-                                data-step-label="PDF to Word" data-step-icon="fa-file-word">
+                                data-step-label="PDF to Word" data-step-icon="fa-file-word" role="button" tabindex="0"
+                                aria-label="Add PDF to Word step to workflow">
                                 <i class="fas fa-file-word"></i>
                                 <span>PDF → Word</span>
                             </div>
                             <div class="step-item" draggable="true" data-step-type="heic_to_jpeg"
-                                data-step-label="HEIC to JPEG" data-step-icon="fa-file-image">
+                                data-step-label="HEIC to JPEG" data-step-icon="fa-file-image" role="button" tabindex="0"
+                                aria-label="Add HEIC to JPEG step to workflow">
                                 <i class="fas fa-file-image"></i>
                                 <span>HEIC → JPEG</span>
                             </div>
                             <div class="step-item" draggable="true" data-step-type="resize_image"
-                                data-step-label="Resize Image" data-step-icon="fa-compress-arrows-alt">
+                                data-step-label="Resize Image" data-step-icon="fa-compress-arrows-alt" role="button"
+                                tabindex="0" aria-label="Add Resize Image step to workflow">
                                 <i class="fas fa-compress-arrows-alt"></i>
                                 <span>Resize Image</span>
                             </div>
@@ -341,9 +345,10 @@
                     <div id="workflow-canvas" class="workflow-canvas">
                         <div class="canvas-placeholder">
                             <i class="fas fa-arrow-down"></i>
-                            <p>Drop steps here to build your workflow</p>
+                            <p>Drop steps here (or click above) to build your workflow</p>
                         </div>
-                        <div id="workflow-steps-container" class="workflow-steps hidden"></div>
+                        <div id="workflow-steps-container" class="workflow-steps hidden" aria-live="polite"
+                            aria-label="Current Workflow Pipeline"></div>
                     </div>
                 </div>
 

--- a/static/script.js
+++ b/static/script.js
@@ -675,6 +675,20 @@ function initWorkflowBuilder() {
         item.ondragend = () => {
             item.style.opacity = '1';
         };
+
+        // Add click handler for accessibility
+        item.onclick = () => {
+            addStepToWorkflow(item.dataset.stepType, item.dataset.stepLabel, item.dataset.stepIcon);
+        };
+
+        // Add keyboard handler explicitly (stops global handler from double-firing)
+        item.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                item.click();
+            }
+        });
     });
 
     // Canvas drop handling

--- a/static/style.css
+++ b/static/style.css
@@ -704,10 +704,16 @@ body {
     user-select: none;
 }
 
-.step-item:hover {
+.step-item:hover,
+.step-item:focus-visible {
     border-color: var(--accent-workflow);
     background: rgba(139, 92, 246, 0.1);
     transform: translateY(-2px);
+}
+
+.step-item:focus-visible {
+    outline: 2px solid var(--accent-workflow);
+    outline-offset: 2px;
 }
 
 .step-item:active {


### PR DESCRIPTION
* 💡 **What**: Added click handlers to workflow step items, making them accessible without drag-and-drop.
* 🎯 **Why**: Drag-and-drop is often inaccessible to keyboard-only and screen reader users.
* ♿ **Accessibility**:
    *   Added `role="button"`, `tabindex="0"`, and `aria-label` to steps.
    *   Added `keydown` handlers for Enter/Space activation.
    *   Added `:focus-visible` styles for better visibility.
    *   Added `aria-live` region to workflow container for screen reader feedback.
* **Verification**: Verified via Playwright scripts (`verify_workflow_v2.py`, `verify_keyboard.py`) confirming click and keyboard interactions add steps correctly.

---
*PR created automatically by Jules for task [8307614684681340985](https://jules.google.com/task/8307614684681340985) started by @BhurkeSiddhesh*