### PR TITLE
feat: Accessibility improvements for Workflow Builder (Click-to-Add)

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-01-31 - Retrofitting Accessibility
 **Learning:** This app relies heavily on `div` elements with `onclick` handlers, which is a common pattern but inaccessible.
 **Action:** Instead of rewriting every component to `<button>`, a cost-effective retrofit is adding `role="button"`, `tabindex="0"`, and a single global delegate listener for `Enter`/`Space` keys. This instantly makes the entire UI keyboard-friendly with minimal code churn (< 20 lines of JS).
+
+## 2026-02-05 - Click-to-Add for Drag & Drop
+**Learning:** Drag & Drop interfaces are inherently inaccessible to keyboard users. A simple "Click-to-Add" handler on the draggable elements provides an immediate, low-cost accessible alternative without changing the visual design.
+**Action:** Whenever implementing DnD, always bind a click/enter handler to the source element to perform the "drop" action programmatically.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,14 @@
 
 ### 2026-02-05
 
+- **feat**: Added click-to-add functionality for workflow steps to support keyboard users (replacing drag-and-drop dependency).
+- **fix**: Added `role="button"`, `tabindex="0"`, and `aria-label` to workflow palette items.
+- **fix**: Added focus visibility styles for step items in palette.
+- **Files**: `static/index.html`, `static/script.js`, `static/style.css`
+- **Verification**: Verified via Playwright script `verification/verify_workflow_a11y.py`.
+
+### 2026-02-05
+
 - **fix**: Merged fix for transparent image conversion (RGBA/P modes) in `image_utils.py` from `palette/a11y` branch.
 - **Files**: `image_utils.py`
 - **Verification**: `pytest tests/test_image_utils.py` passed.

--- a/static/index.html
+++ b/static/index.html
@@ -314,22 +314,22 @@
                         <h3>2. Available Steps</h3>
                         <div class="step-palette">
                             <div class="step-item" draggable="true" data-step-type="remove_password"
-                                data-step-label="Unlock PDF" data-step-icon="fa-unlock">
+                                data-step-label="Unlock PDF" data-step-icon="fa-unlock" role="button" tabindex="0" aria-label="Add Unlock PDF step to workflow">
                                 <i class="fas fa-unlock"></i>
                                 <span>Unlock PDF</span>
                             </div>
                             <div class="step-item" draggable="true" data-step-type="pdf_to_word"
-                                data-step-label="PDF to Word" data-step-icon="fa-file-word">
+                                data-step-label="PDF to Word" data-step-icon="fa-file-word" role="button" tabindex="0" aria-label="Add PDF to Word step to workflow">
                                 <i class="fas fa-file-word"></i>
                                 <span>PDF → Word</span>
                             </div>
                             <div class="step-item" draggable="true" data-step-type="heic_to_jpeg"
-                                data-step-label="HEIC to JPEG" data-step-icon="fa-file-image">
+                                data-step-label="HEIC to JPEG" data-step-icon="fa-file-image" role="button" tabindex="0" aria-label="Add HEIC to JPEG step to workflow">
                                 <i class="fas fa-file-image"></i>
                                 <span>HEIC → JPEG</span>
                             </div>
                             <div class="step-item" draggable="true" data-step-type="resize_image"
-                                data-step-label="Resize Image" data-step-icon="fa-compress-arrows-alt">
+                                data-step-label="Resize Image" data-step-icon="fa-compress-arrows-alt" role="button" tabindex="0" aria-label="Add Resize Image step to workflow">
                                 <i class="fas fa-compress-arrows-alt"></i>
                                 <span>Resize Image</span>
                             </div>

--- a/static/script.js
+++ b/static/script.js
@@ -675,6 +675,11 @@ function initWorkflowBuilder() {
         item.ondragend = () => {
             item.style.opacity = '1';
         };
+
+        // A11y: Click to add step
+        item.onclick = () => {
+            addStepToWorkflow(item.dataset.stepType, item.dataset.stepLabel, item.dataset.stepIcon);
+        };
     });
 
     // Canvas drop handling

--- a/static/style.css
+++ b/static/style.css
@@ -1090,7 +1090,8 @@ body {
 /* Accessibility Focus Styles */
 .tool-card:focus-visible,
 .action-card:focus-visible,
-.drop-zone:focus-visible {
+.drop-zone:focus-visible,
+.step-item:focus-visible {
     outline: 2px solid var(--primary);
     outline-offset: 4px;
     box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.3);


### PR DESCRIPTION
This PR improves accessibility for the Workflow Builder by implementing a "Click-to-Add" functionality. Previously, adding steps required drag-and-drop, which is inaccessible to keyboard-only users. Now, users can tab to a step and press Enter (or click) to add it to the workflow. The visual design remains unchanged, but semantic attributes and focus styles have been added.

---
*PR created automatically by Jules for task [6998421919183460152](https://jules.google.com/task/6998421919183460152) started by @BhurkeSiddhesh*