### PR TITLE
fix: add page breaks when merging recovered DOCX pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,12 @@
 
 ### 2026-02-03
 
+- **fix**: Added missing page breaks when merging recovered DOCX pages.
+- **refactor**: Extracted merging logic into `merge_docx_files` helper function.
+- **test**: Added unit tests for merging logic in `tests/test_docx_merge.py`.
+- **Files**: `pdf_utils.py`, `tests/test_docx_merge.py`
+- **Verification**: `python -m pytest tests/test_docx_merge.py` passed.
+
 - **chore**: Updated `agency.yaml` with detailed, natural language descriptions for specialized agent roles (Architect, PDF/Image Specialists, Frontend, QA/Watchdog, Workflow Orchestrator).
 - **fix**: Wrapped blocking workflow steps in `run_in_threadpool` to enable real-time SSE progress updates.
 - **feat**: Enhanced workflow UI with pulsing animations for processing steps and green gradients for completed steps.

--- a/pdf_utils.py
+++ b/pdf_utils.py
@@ -81,6 +81,21 @@ def pdf_to_docx(input_path: str, output_dir: str, password: str = None) -> str:
     
     return str(output_file)
 
+
+def merge_docx_files(input_files: list[str], output_file: str) -> None:
+    """Merges multiple DOCX files into one, inserting page breaks between them."""
+    if not input_files:
+        raise ValueError("No input files provided for merging.")
+
+    master = Document_docx(input_files[0])
+    composer = Composer(master)
+
+    for docx_path in input_files[1:]:
+        master.add_page_break()
+        composer.append(Document_docx(docx_path))
+
+    composer.save(output_file)
+
 def pdf_to_word_paddle(input_path: str, output_dir: str, password: str = None) -> str:
     """Converts PDF to DOCX using PaddleOCR Layout Recovery (Slow, AI-based)."""
     print(f"[AI] Starting AI conversion for: {input_path}")
@@ -167,15 +182,7 @@ def pdf_to_word_paddle(input_path: str, output_dir: str, password: str = None) -
              raise Exception("No pages were successfully converted using AI engine.")
 
         # Merge files
-        master = Document_docx(str(docx_files[0]))
-        composer = Composer(master)
-
-        for docx_path in docx_files[1:]:
-            # @jules: Append usually doesn't include a page break. 
-            # We might want to explicitly add one if the pages are getting merged into one long stream.
-            composer.append(Document_docx(str(docx_path)))
-
-        composer.save(str(output_file))
+        merge_docx_files([str(f) for f in docx_files], str(output_file))
         doc.close()
 
     finally:

--- a/tests/test_docx_merge.py
+++ b/tests/test_docx_merge.py
@@ -1,0 +1,52 @@
+import pytest
+from docx import Document
+from pdf_utils import merge_docx_files
+import zipfile
+import os
+
+def create_simple_docx(path, text):
+    doc = Document()
+    doc.add_paragraph(text)
+    doc.save(path)
+
+def test_merge_docx_files_with_page_break(tmp_path):
+    # Setup
+    doc1 = tmp_path / "doc1.docx"
+    doc2 = tmp_path / "doc2.docx"
+    output = tmp_path / "merged.docx"
+
+    create_simple_docx(str(doc1), "Content 1")
+    create_simple_docx(str(doc2), "Content 2")
+
+    # Execute
+    merge_docx_files([str(doc1), str(doc2)], str(output))
+
+    # Verify
+    assert output.exists()
+
+    # Check for page break XML
+    with zipfile.ZipFile(str(output), 'r') as z:
+        xml_content = z.read('word/document.xml').decode('utf-8')
+        # We expect a page break.
+        # Note: python-docx inserts page break as <w:br w:type="page"/>
+        assert 'w:type="page"' in xml_content, "Page break not found in merged document"
+
+def test_merge_single_file(tmp_path):
+    doc1 = tmp_path / "doc1.docx"
+    output = tmp_path / "merged.docx"
+
+    create_simple_docx(str(doc1), "Content 1")
+
+    merge_docx_files([str(doc1)], str(output))
+
+    assert output.exists()
+
+    # Should NOT have a page break (only one doc)
+    # Unless there was one in the original doc, which there isn't.
+    with zipfile.ZipFile(str(output), 'r') as z:
+        xml_content = z.read('word/document.xml').decode('utf-8')
+        assert 'w:type="page"' not in xml_content, "Unexpected page break in single file merge"
+
+def test_merge_no_files():
+    with pytest.raises(ValueError):
+        merge_docx_files([], "output.docx")


### PR DESCRIPTION
This PR fixes an issue where merging multiple DOCX files (resulting from PDF page recovery) resulted in a continuous stream of text without page breaks.

Changes:
- Refactored the merging logic in `pdf_utils.py` into a reusable `merge_docx_files` function.
- Implemented `master.add_page_break()` before appending each new document in the loop.
- Added a new test file `tests/test_docx_merge.py` to verify that page breaks are correctly inserted in the XML structure of the output DOCX.
- Updated `AGENTS.md` with the change log entry.

---
*PR created automatically by Jules for task [2558410593359795762](https://jules.google.com/task/2558410593359795762) started by @BhurkeSiddhesh*