### PR TITLE
🔒 Security Fix: Use unique temporary filenames to prevent race conditions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,14 @@
 
 > **CRITICAL**: Add entry here BEFORE every commit.
 
+### 2026-02-04
+
+- **security**: Fixed a race condition vulnerability in file uploads where concurrent uploads with the same name could overwrite each other.
+- **fix**: Implemented unique temporary filenames using UUIDs for all file processing endpoints.
+- **test**: Added reproduction and verification test case `tests/test_security_fix.py`.
+- **Files**: `main.py`, `tests/test_security_fix.py`
+- **Verification**: `pytest tests/test_security_fix.py` passed.
+
 ### 2026-02-03
 
 - **chore**: Updated `agency.yaml` with detailed, natural language descriptions for specialized agent roles (Architect, PDF/Image Specialists, Frontend, QA/Watchdog, Workflow Orchestrator).

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 import shutil
 import os
+import uuid
 from pathlib import Path
 from fastapi.concurrency import run_in_threadpool
 from pdf_utils import remove_pdf_password, pdf_to_docx, pdf_to_word_paddle
@@ -56,7 +57,11 @@ async def read_index():
 
 @app.post("/api/pdf/remove-password")
 async def api_remove_password(file: UploadFile = File(...), password: str = Form(...)):
-    temp_path = UPLOAD_DIR / file.filename
+    # Generate unique filename to prevent race conditions
+    safe_filename = Path(file.filename).name
+    temp_filename = f"{uuid.uuid4()}_{safe_filename}"
+    temp_path = UPLOAD_DIR / temp_filename
+
     try:
         with temp_path.open("wb") as buffer:
             shutil.copyfileobj(file.file, buffer)
@@ -74,8 +79,12 @@ async def api_remove_password(file: UploadFile = File(...), password: str = Form
 
 @app.post("/api/pdf/convert-to-word")
 async def api_convert_to_word(file: UploadFile = File(...), use_ai: bool = Form(False), password: str = Form(None)):
-    temp_path = UPLOAD_DIR / file.filename
-    print(f"[DEBUG] Converting: {file.filename}, use_ai={use_ai}, password={'***' if password else 'None'}")
+    # Generate unique filename to prevent race conditions
+    safe_filename = Path(file.filename).name
+    temp_filename = f"{uuid.uuid4()}_{safe_filename}"
+    temp_path = UPLOAD_DIR / temp_filename
+
+    print(f"[DEBUG] Converting: {file.filename} -> {temp_filename}, use_ai={use_ai}, password={'***' if password else 'None'}")
     try:
         with temp_path.open("wb") as buffer:
             shutil.copyfileobj(file.file, buffer)
@@ -110,8 +119,12 @@ async def api_convert_to_word(file: UploadFile = File(...), use_ai: bool = Form(
 @app.post("/api/image/heic-to-jpeg")
 async def api_heic_to_jpeg(file: UploadFile = File(...), quality: int = Form(95)):
     """Convert HEIC/HEIF image to JPEG format."""
-    temp_path = UPLOAD_DIR / file.filename
-    print(f"[DEBUG] Converting HEIC: {file.filename}, quality={quality}")
+    # Generate unique filename to prevent race conditions
+    safe_filename = Path(file.filename).name
+    temp_filename = f"{uuid.uuid4()}_{safe_filename}"
+    temp_path = UPLOAD_DIR / temp_filename
+
+    print(f"[DEBUG] Converting HEIC: {file.filename} -> {temp_filename}, quality={quality}")
     try:
         with temp_path.open("wb") as buffer:
             shutil.copyfileobj(file.file, buffer)
@@ -141,8 +154,12 @@ async def api_resize_image(
     target_size_kb: int = Form(None)
 ):
     """Resize image based on parameters."""
-    temp_path = UPLOAD_DIR / file.filename
-    print(f"[DEBUG] Resizing image: {file.filename}, mode={mode}")
+    # Generate unique filename to prevent race conditions
+    safe_filename = Path(file.filename).name
+    temp_filename = f"{uuid.uuid4()}_{safe_filename}"
+    temp_path = UPLOAD_DIR / temp_filename
+
+    print(f"[DEBUG] Resizing image: {file.filename} -> {temp_filename}, mode={mode}")
     try:
         with temp_path.open("wb") as buffer:
             shutil.copyfileobj(file.file, buffer)
@@ -180,8 +197,12 @@ async def api_crop_image(
     height: int = Form(...)
 ):
     """Crop image based on coordinates."""
-    temp_path = UPLOAD_DIR / file.filename
-    print(f"[DEBUG] Cropping image: {file.filename}, x={x}, y={y}, w={width}, h={height}")
+    # Generate unique filename to prevent race conditions
+    safe_filename = Path(file.filename).name
+    temp_filename = f"{uuid.uuid4()}_{safe_filename}"
+    temp_path = UPLOAD_DIR / temp_filename
+
+    print(f"[DEBUG] Cropping image: {file.filename} -> {temp_filename}, x={x}, y={y}, w={width}, h={height}")
     try:
         with temp_path.open("wb") as buffer:
             shutil.copyfileobj(file.file, buffer)
@@ -212,9 +233,12 @@ async def execute_workflow(file: UploadFile = File(...), steps: str = Form(...))
     import json
     from fastapi.responses import StreamingResponse
     
-    temp_path = UPLOAD_DIR / file.filename
+    # Generate unique filename to prevent race conditions
+    safe_filename = Path(file.filename).name
+    temp_filename = f"{uuid.uuid4()}_{safe_filename}"
+    temp_path = UPLOAD_DIR / temp_filename
     
-    print(f"[DEBUG] Workflow started: {file.filename}, steps={steps}")
+    print(f"[DEBUG] Workflow started: {file.filename} -> {temp_filename}, steps={steps}")
     
     # Parse steps JSON
     try:

--- a/tests/test_security_fix.py
+++ b/tests/test_security_fix.py
@@ -1,0 +1,51 @@
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+from main import app
+import pytest
+from pathlib import Path
+
+client = TestClient(app)
+
+@pytest.fixture
+def mock_dirs(tmp_path):
+    upload_dir = tmp_path / "uploads"
+    output_dir = tmp_path / "outputs"
+    upload_dir.mkdir()
+    output_dir.mkdir()
+    with patch("main.UPLOAD_DIR", upload_dir), patch("main.OUTPUT_DIR", output_dir):
+        yield upload_dir, output_dir
+
+def test_upload_filename_is_unique(mock_dirs):
+    upload_dir, _ = mock_dirs
+
+    # We mock shutil.copyfileobj to intercept the file write
+    with patch("main.shutil.copyfileobj") as mock_copy:
+        # Mock the processing function to avoid actual PDF processing
+        with patch("main.remove_pdf_password") as mock_remove:
+            mock_remove.return_value = "output.pdf"
+
+            files = {"file": ("test.pdf", b"dummy content", "application/pdf")}
+            data = {"password": "pass"}
+
+            response = client.post("/api/pdf/remove-password", files=files, data=data)
+
+            assert response.status_code == 200
+
+            # Check copyfileobj calls
+            assert mock_copy.called
+            args, _ = mock_copy.call_args
+            dest_buffer = args[1]
+            dest_path = dest_buffer.name
+
+            print(f"Destination path: {dest_path}")
+
+            filename = Path(dest_path).name
+
+            # Security check: filename should NOT be exactly "test.pdf"
+            # It should be randomized (e.g. UUID_test.pdf)
+            if filename == "test.pdf":
+                pytest.fail(f"VULNERABILITY DETECTED: Uploaded file saved as '{filename}' without randomization.")
+
+            assert "test.pdf" in filename
+            # UUID is 36 chars. + 1 underscore + 8 chars for "test.pdf" = 45 chars approx.
+            assert len(filename) > 36


### PR DESCRIPTION
- **What:** Fixed an insecure temporary file handling vulnerability (race condition) in `main.py` where concurrent uploads with the same filename could overwrite each other in the shared `uploads/` directory.
- **Risk:** High. An attacker could overwrite another user's file during processing, leading to data leakage or processing of incorrect files.
- **Solution:** Implemented unique temporary filenames using `uuid.uuid4()` for all file processing endpoints (`remove-password`, `convert-to-word`, `heic-to-jpeg`, `resize`, `crop`, `workflow`). The original filename is preserved as a suffix for clarity but prefixed with a UUID to ensure uniqueness.
- **Verification:** Added `tests/test_security_fix.py` which reproduces the issue (by failing if the filename is not randomized) and verifies the fix. Ran all tests in `tests/` and they passed.

---
*PR created automatically by Jules for task [8024907961027201130](https://jules.google.com/task/8024907961027201130) started by @BhurkeSiddhesh*