### PR TITLE
Expand PDF/Image toolsets + new Excel & PPT pages + Workflow steps

### DIFF
--- a/main.py
+++ b/main.py
@@ -832,7 +832,11 @@ async def api_merge_pptx(
 
 
 @app.post("/api/workflow/execute")
-async def execute_workflow(file: UploadFile = File(...), steps: str = Form(...)):
+async def execute_workflow(
+    file: UploadFile = File(...),
+    steps: str = Form(...),
+    _auth: str = Depends(require_auth),
+):
     """Execute a multi-step workflow on a file with SSE progress streaming."""
     import json
     from fastapi.responses import StreamingResponse

--- a/main.py
+++ b/main.py
@@ -9,8 +9,35 @@ import os
 import uuid
 from pathlib import Path
 from fastapi.concurrency import run_in_threadpool
-from scripts.pdf_utils import remove_pdf_password, pdf_to_docx, pdf_to_word_paddle, extract_pdf_pages, compress_pdf
-from scripts.image_utils import heic_to_jpeg
+from scripts.pdf_utils import (
+    remove_pdf_password,
+    pdf_to_docx,
+    pdf_to_word_paddle,
+    extract_pdf_pages,
+    compress_pdf,
+    merge_pdfs,
+    add_watermark,
+    pdf_to_images_zip,
+    sign_pdf,
+)
+from scripts.image_utils import (
+    heic_to_jpeg,
+    rotate_image,
+    compress_image,
+    convert_image_format,
+    watermark_image,
+)
+from scripts.excel_utils import (
+    excel_to_pdf,
+    csv_to_xlsx,
+    xlsx_to_csv,
+    merge_excel_files,
+)
+from scripts.ppt_utils import (
+    ppt_to_pdf,
+    ppt_to_images_zip,
+    merge_pptx,
+)
 
 app = FastAPI(title="File Forge API")
 
@@ -151,7 +178,7 @@ async def api_convert_to_word(
             output_path = pdf_to_word_paddle(str(temp_path), str(OUTPUT_DIR), password)
             message = "Converted to Word with AI Layout Recovery"
         else:
-            output_path = pdf_to_docx(str(temp_path), str(OUTPUT_DIR), password)
+            output_path = await run_in_threadpool(pdf_to_docx, str(temp_path), str(OUTPUT_DIR), password)
             message = "Converted to Word (Standard)"
 
         print(f"[DEBUG] Conversion successful: {output_path}")
@@ -234,6 +261,172 @@ async def api_compress_pdf(
                 os.remove(temp_path)
             except PermissionError:
                 pass
+
+
+@app.post("/api/pdf/merge")
+async def api_merge_pdfs(
+    files: List[UploadFile] = File(...),
+    passwords: Optional[str] = Form(None),
+    _auth: str = Depends(require_auth),
+):
+    """Merge multiple PDFs into one. `passwords` is an optional comma-separated list aligned with files."""
+    if not files or len(files) < 2:
+        raise HTTPException(status_code=400, detail="Provide at least two PDF files to merge.")
+
+    temp_paths: List[Path] = []
+    try:
+        for f in files:
+            safe_filename = Path(f.filename.replace("\\", "/")).name
+            unique_filename = f"{uuid.uuid4()}_{safe_filename}"
+            temp_path = UPLOAD_DIR / unique_filename
+            with temp_path.open("wb") as buffer:
+                shutil.copyfileobj(f.file, buffer)
+            temp_paths.append(temp_path)
+
+        pwd_list = None
+        if passwords:
+            pwd_list = [p if p else None for p in passwords.split(",")]
+
+        output_path = await run_in_threadpool(
+            merge_pdfs, [str(p) for p in temp_paths], str(OUTPUT_DIR), pwd_list
+        )
+        return {"status": "success", "message": "PDFs merged", "filename": Path(output_path).name}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        import traceback
+        print(f"[ERROR] PDF merge failed: {e}")
+        traceback.print_exc()
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        for p in temp_paths:
+            if p.exists():
+                try:
+                    os.remove(p)
+                except PermissionError:
+                    pass
+
+
+@app.post("/api/pdf/watermark")
+async def api_add_watermark(
+    file: UploadFile = File(...),
+    text: str = Form(...),
+    position: str = Form("diagonal"),
+    opacity: float = Form(0.3),
+    password: str = Form(None),
+    _auth: str = Depends(require_auth),
+):
+    """Stamp a text watermark on every page."""
+    safe_filename = Path(file.filename.replace("\\", "/")).name
+    unique_filename = f"{uuid.uuid4()}_{safe_filename}"
+    temp_path = UPLOAD_DIR / unique_filename
+    try:
+        with temp_path.open("wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+
+        output_path = await run_in_threadpool(
+            add_watermark, str(temp_path), str(OUTPUT_DIR), text, position, opacity, password or None
+        )
+        return {"status": "success", "message": "Watermark added", "filename": Path(output_path).name}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        import traceback
+        print(f"[ERROR] Watermark failed: {e}")
+        traceback.print_exc()
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        if temp_path.exists():
+            try:
+                os.remove(temp_path)
+            except PermissionError:
+                pass
+
+
+@app.post("/api/pdf/to-images")
+async def api_pdf_to_images(
+    file: UploadFile = File(...),
+    dpi: int = Form(150),
+    fmt: str = Form("jpg"),
+    password: str = Form(None),
+    _auth: str = Depends(require_auth),
+):
+    """Render every page to an image and return a zip."""
+    safe_filename = Path(file.filename.replace("\\", "/")).name
+    unique_filename = f"{uuid.uuid4()}_{safe_filename}"
+    temp_path = UPLOAD_DIR / unique_filename
+    try:
+        with temp_path.open("wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+
+        result = await run_in_threadpool(
+            pdf_to_images_zip, str(temp_path), str(OUTPUT_DIR), dpi, fmt, password or None
+        )
+        return {
+            "status": "success",
+            "message": f"Rendered {result['page_count']} page(s) to images",
+            "filename": Path(result["output_path"]).name,
+            "page_count": result["page_count"],
+        }
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        import traceback
+        print(f"[ERROR] PDF to images failed: {e}")
+        traceback.print_exc()
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        if temp_path.exists():
+            try:
+                os.remove(temp_path)
+            except PermissionError:
+                pass
+
+
+@app.post("/api/pdf/sign")
+async def api_sign_pdf(
+    file: UploadFile = File(...),
+    signature: UploadFile = File(...),
+    page: int = Form(1),
+    x: float = Form(0.65),
+    y: float = Form(0.85),
+    width: float = Form(0.2),
+    password: str = Form(None),
+    _auth: str = Depends(require_auth),
+):
+    """Stamp a signature image onto the chosen page."""
+    sig_ct = (signature.content_type or "").lower()
+    if sig_ct not in ("image/png", "image/jpeg", "image/jpg"):
+        raise HTTPException(status_code=400, detail="Signature must be a PNG or JPEG image.")
+
+    safe_pdf = Path(file.filename.replace("\\", "/")).name
+    safe_sig = Path(signature.filename.replace("\\", "/")).name
+    pdf_path = UPLOAD_DIR / f"{uuid.uuid4()}_{safe_pdf}"
+    sig_path = UPLOAD_DIR / f"{uuid.uuid4()}_{safe_sig}"
+    try:
+        with pdf_path.open("wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+        with sig_path.open("wb") as buffer:
+            shutil.copyfileobj(signature.file, buffer)
+
+        output_path = await run_in_threadpool(
+            sign_pdf, str(pdf_path), str(sig_path), str(OUTPUT_DIR), page, x, y, width, password or None
+        )
+        return {"status": "success", "message": "Signature added", "filename": Path(output_path).name}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        import traceback
+        print(f"[ERROR] Sign PDF failed: {e}")
+        traceback.print_exc()
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        for p in (pdf_path, sig_path):
+            if p.exists():
+                try:
+                    os.remove(p)
+                except PermissionError:
+                    pass
 
 
 @app.post("/api/image/heic-to-jpeg")
@@ -341,6 +534,303 @@ async def api_crop_image(
                 pass
 
 
+@app.post("/api/image/rotate")
+async def api_rotate_image(
+    file: UploadFile = File(...),
+    angle: float = Form(90),
+    quality: int = Form(95),
+    _auth: str = Depends(require_auth),
+):
+    safe_filename = Path(file.filename.replace("\\", "/")).name
+    temp_path = UPLOAD_DIR / f"{uuid.uuid4()}_{safe_filename}"
+    try:
+        with temp_path.open("wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+        output_path = await run_in_threadpool(rotate_image, str(temp_path), str(OUTPUT_DIR), angle, quality)
+        return {"status": "success", "message": f"Rotated by {angle}°", "filename": Path(output_path).name}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        import traceback; traceback.print_exc()
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        if temp_path.exists():
+            try: os.remove(temp_path)
+            except PermissionError: pass
+
+
+@app.post("/api/image/compress")
+async def api_compress_image(
+    file: UploadFile = File(...),
+    quality: int = Form(70),
+    _auth: str = Depends(require_auth),
+):
+    safe_filename = Path(file.filename.replace("\\", "/")).name
+    temp_path = UPLOAD_DIR / f"{uuid.uuid4()}_{safe_filename}"
+    try:
+        with temp_path.open("wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+        result = await run_in_threadpool(compress_image, str(temp_path), str(OUTPUT_DIR), quality)
+        return {
+            "status": "success",
+            "message": "Image compressed",
+            "filename": Path(result["output_path"]).name,
+            "original_size": result["original_size"],
+            "compressed_size": result["compressed_size"],
+            "reduction_pct": result["reduction_pct"],
+        }
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        import traceback; traceback.print_exc()
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        if temp_path.exists():
+            try: os.remove(temp_path)
+            except PermissionError: pass
+
+
+@app.post("/api/image/convert")
+async def api_convert_image(
+    file: UploadFile = File(...),
+    target_format: str = Form(...),
+    quality: int = Form(90),
+    _auth: str = Depends(require_auth),
+):
+    safe_filename = Path(file.filename.replace("\\", "/")).name
+    temp_path = UPLOAD_DIR / f"{uuid.uuid4()}_{safe_filename}"
+    try:
+        with temp_path.open("wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+        output_path = await run_in_threadpool(
+            convert_image_format, str(temp_path), str(OUTPUT_DIR), target_format, quality
+        )
+        return {"status": "success", "message": f"Converted to {target_format.upper()}", "filename": Path(output_path).name}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        import traceback; traceback.print_exc()
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        if temp_path.exists():
+            try: os.remove(temp_path)
+            except PermissionError: pass
+
+
+@app.post("/api/image/watermark")
+async def api_watermark_image(
+    file: UploadFile = File(...),
+    text: str = Form(...),
+    position: str = Form("bottom-right"),
+    opacity: float = Form(0.4),
+    color: str = Form("white"),
+    _auth: str = Depends(require_auth),
+):
+    safe_filename = Path(file.filename.replace("\\", "/")).name
+    temp_path = UPLOAD_DIR / f"{uuid.uuid4()}_{safe_filename}"
+    try:
+        with temp_path.open("wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+        output_path = await run_in_threadpool(
+            watermark_image, str(temp_path), str(OUTPUT_DIR), text, position, opacity, color
+        )
+        return {"status": "success", "message": "Watermark added", "filename": Path(output_path).name}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        import traceback; traceback.print_exc()
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        if temp_path.exists():
+            try: os.remove(temp_path)
+            except PermissionError: pass
+
+
+# --- Excel Routes ---
+
+@app.post("/api/excel/to-pdf")
+async def api_excel_to_pdf(
+    file: UploadFile = File(...),
+    _auth: str = Depends(require_auth),
+):
+    safe_filename = Path(file.filename.replace("\\", "/")).name
+    temp_path = UPLOAD_DIR / f"{uuid.uuid4()}_{safe_filename}"
+    try:
+        with temp_path.open("wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+        output_path = await run_in_threadpool(excel_to_pdf, str(temp_path), str(OUTPUT_DIR))
+        return {"status": "success", "message": "Excel converted to PDF", "filename": Path(output_path).name}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        import traceback; traceback.print_exc()
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        if temp_path.exists():
+            try: os.remove(temp_path)
+            except PermissionError: pass
+
+
+@app.post("/api/excel/csv-to-xlsx")
+async def api_csv_to_xlsx(
+    file: UploadFile = File(...),
+    delimiter: str = Form(","),
+    _auth: str = Depends(require_auth),
+):
+    safe_filename = Path(file.filename.replace("\\", "/")).name
+    temp_path = UPLOAD_DIR / f"{uuid.uuid4()}_{safe_filename}"
+    try:
+        with temp_path.open("wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+        output_path = await run_in_threadpool(csv_to_xlsx, str(temp_path), str(OUTPUT_DIR), delimiter)
+        return {"status": "success", "message": "CSV converted to XLSX", "filename": Path(output_path).name}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        import traceback; traceback.print_exc()
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        if temp_path.exists():
+            try: os.remove(temp_path)
+            except PermissionError: pass
+
+
+@app.post("/api/excel/xlsx-to-csv")
+async def api_xlsx_to_csv(
+    file: UploadFile = File(...),
+    sheet: str = Form(None),
+    _auth: str = Depends(require_auth),
+):
+    safe_filename = Path(file.filename.replace("\\", "/")).name
+    temp_path = UPLOAD_DIR / f"{uuid.uuid4()}_{safe_filename}"
+    try:
+        with temp_path.open("wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+        output_path = await run_in_threadpool(xlsx_to_csv, str(temp_path), str(OUTPUT_DIR), sheet or None)
+        return {"status": "success", "message": "XLSX converted to CSV", "filename": Path(output_path).name}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        import traceback; traceback.print_exc()
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        if temp_path.exists():
+            try: os.remove(temp_path)
+            except PermissionError: pass
+
+
+@app.post("/api/excel/merge")
+async def api_merge_excel(
+    files: List[UploadFile] = File(...),
+    _auth: str = Depends(require_auth),
+):
+    if not files or len(files) < 2:
+        raise HTTPException(status_code=400, detail="Provide at least two Excel files to merge.")
+    temp_paths: List[Path] = []
+    try:
+        for f in files:
+            safe = Path(f.filename.replace("\\", "/")).name
+            tp = UPLOAD_DIR / f"{uuid.uuid4()}_{safe}"
+            with tp.open("wb") as buffer:
+                shutil.copyfileobj(f.file, buffer)
+            temp_paths.append(tp)
+        output_path = await run_in_threadpool(merge_excel_files, [str(p) for p in temp_paths], str(OUTPUT_DIR))
+        return {"status": "success", "message": "Excel files merged", "filename": Path(output_path).name}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        import traceback; traceback.print_exc()
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        for p in temp_paths:
+            if p.exists():
+                try: os.remove(p)
+                except PermissionError: pass
+
+
+# --- PPT Routes ---
+
+@app.post("/api/ppt/to-pdf")
+async def api_ppt_to_pdf(
+    file: UploadFile = File(...),
+    _auth: str = Depends(require_auth),
+):
+    safe_filename = Path(file.filename.replace("\\", "/")).name
+    temp_path = UPLOAD_DIR / f"{uuid.uuid4()}_{safe_filename}"
+    try:
+        with temp_path.open("wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+        output_path = await run_in_threadpool(ppt_to_pdf, str(temp_path), str(OUTPUT_DIR))
+        return {"status": "success", "message": "PPT converted to PDF (best-effort layout)", "filename": Path(output_path).name}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        import traceback; traceback.print_exc()
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        if temp_path.exists():
+            try: os.remove(temp_path)
+            except PermissionError: pass
+
+
+@app.post("/api/ppt/to-images")
+async def api_ppt_to_images(
+    file: UploadFile = File(...),
+    fmt: str = Form("png"),
+    _auth: str = Depends(require_auth),
+):
+    safe_filename = Path(file.filename.replace("\\", "/")).name
+    temp_path = UPLOAD_DIR / f"{uuid.uuid4()}_{safe_filename}"
+    try:
+        with temp_path.open("wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+        result = await run_in_threadpool(ppt_to_images_zip, str(temp_path), str(OUTPUT_DIR), fmt)
+        return {
+            "status": "success",
+            "message": f"Rendered {result['slide_count']} slide(s)",
+            "filename": Path(result["output_path"]).name,
+            "slide_count": result["slide_count"],
+        }
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        import traceback; traceback.print_exc()
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        if temp_path.exists():
+            try: os.remove(temp_path)
+            except PermissionError: pass
+
+
+@app.post("/api/ppt/merge")
+async def api_merge_pptx(
+    files: List[UploadFile] = File(...),
+    _auth: str = Depends(require_auth),
+):
+    if not files or len(files) < 2:
+        raise HTTPException(status_code=400, detail="Provide at least two PPTX files to merge.")
+    temp_paths: List[Path] = []
+    try:
+        for f in files:
+            safe = Path(f.filename.replace("\\", "/")).name
+            tp = UPLOAD_DIR / f"{uuid.uuid4()}_{safe}"
+            with tp.open("wb") as buffer:
+                shutil.copyfileobj(f.file, buffer)
+            temp_paths.append(tp)
+        output_path = await run_in_threadpool(merge_pptx, [str(p) for p in temp_paths], str(OUTPUT_DIR))
+        return {"status": "success", "message": "PPTX files merged", "filename": Path(output_path).name}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        import traceback; traceback.print_exc()
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        for p in temp_paths:
+            if p.exists():
+                try: os.remove(p)
+                except PermissionError: pass
+
+
 @app.post("/api/workflow/execute")
 async def execute_workflow(file: UploadFile = File(...), steps: str = Form(...)):
     """Execute a multi-step workflow on a file with SSE progress streaming."""
@@ -438,6 +928,57 @@ async def execute_workflow(file: UploadFile = File(...), steps: str = Form(...))
                     level = config.get('level', 'medium')
                     password = config.get('password') or None
                     result = await run_in_threadpool(compress_pdf, str(current_file), str(OUTPUT_DIR), level, password)
+                    current_file = Path(result['output_path'])
+
+                elif step_type == 'rotate_image':
+                    angle = config.get('angle', 90)
+                    output_path = await run_in_threadpool(rotate_image, str(current_file), str(OUTPUT_DIR), angle)
+                    current_file = Path(output_path)
+
+                elif step_type == 'compress_image':
+                    quality = config.get('quality', 70)
+                    result = await run_in_threadpool(compress_image, str(current_file), str(OUTPUT_DIR), quality)
+                    current_file = Path(result['output_path'])
+
+                elif step_type == 'convert_image':
+                    target_format = config.get('target_format', 'jpg')
+                    quality = config.get('quality', 90)
+                    output_path = await run_in_threadpool(
+                        convert_image_format, str(current_file), str(OUTPUT_DIR), target_format, quality
+                    )
+                    current_file = Path(output_path)
+
+                elif step_type == 'watermark_image':
+                    text = config.get('text', 'WATERMARK')
+                    position = config.get('position', 'bottom-right')
+                    opacity = config.get('opacity', 0.4)
+                    color = config.get('color', 'white')
+                    output_path = await run_in_threadpool(
+                        watermark_image, str(current_file), str(OUTPUT_DIR), text, position, opacity, color
+                    )
+                    current_file = Path(output_path)
+
+                elif step_type == 'excel_to_pdf':
+                    output_path = await run_in_threadpool(excel_to_pdf, str(current_file), str(OUTPUT_DIR))
+                    current_file = Path(output_path)
+
+                elif step_type == 'csv_to_xlsx':
+                    delimiter = config.get('delimiter', ',')
+                    output_path = await run_in_threadpool(csv_to_xlsx, str(current_file), str(OUTPUT_DIR), delimiter)
+                    current_file = Path(output_path)
+
+                elif step_type == 'xlsx_to_csv':
+                    sheet = config.get('sheet') or None
+                    output_path = await run_in_threadpool(xlsx_to_csv, str(current_file), str(OUTPUT_DIR), sheet)
+                    current_file = Path(output_path)
+
+                elif step_type == 'ppt_to_pdf':
+                    output_path = await run_in_threadpool(ppt_to_pdf, str(current_file), str(OUTPUT_DIR))
+                    current_file = Path(output_path)
+
+                elif step_type == 'ppt_to_images':
+                    fmt = config.get('fmt', 'png')
+                    result = await run_in_threadpool(ppt_to_images_zip, str(current_file), str(OUTPUT_DIR), fmt)
                     current_file = Path(result['output_path'])
 
                 else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,6 @@ pillow-heif
 onnxruntime
 aiofiles
 gunicorn
+openpyxl
+pandas
+python-pptx

--- a/scripts/excel_utils.py
+++ b/scripts/excel_utils.py
@@ -1,0 +1,192 @@
+"""
+Excel/CSV utilities for File Forge.
+
+Pure-Python implementations using openpyxl + pandas + reportlab.
+Excel→PDF renders sheets as styled tables, NOT as a Microsoft-Office-grade rendering;
+cell colors, merged cells, charts, and conditional formatting are approximated or dropped.
+"""
+import csv
+import uuid
+from pathlib import Path
+from typing import List
+
+from openpyxl import Workbook, load_workbook
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import A4, landscape
+from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+from reportlab.platypus import (
+    SimpleDocTemplate, Table, TableStyle, Paragraph, Spacer, PageBreak,
+)
+
+
+def _sanitize_cell(value) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+def excel_to_pdf(input_path: str, output_dir: str) -> str:
+    """Render every sheet of an .xlsx workbook as a table in a PDF."""
+    input_file = Path(input_path)
+    output_file = Path(output_dir) / f"{input_file.stem}.pdf"
+
+    wb = load_workbook(input_file, data_only=True, read_only=True)
+    try:
+        if not wb.sheetnames:
+            raise ValueError("Workbook has no sheets.")
+
+        styles = getSampleStyleSheet()
+        title_style = ParagraphStyle(
+            "SheetTitle", parent=styles["Heading2"], spaceAfter=10
+        )
+
+        doc = SimpleDocTemplate(
+            str(output_file),
+            pagesize=landscape(A4),
+            leftMargin=24, rightMargin=24, topMargin=24, bottomMargin=24,
+        )
+        story = []
+
+        for s_idx, sheet_name in enumerate(wb.sheetnames):
+            ws = wb[sheet_name]
+            story.append(Paragraph(f"Sheet: {sheet_name}", title_style))
+
+            rows = []
+            for row in ws.iter_rows(values_only=True):
+                rows.append([_sanitize_cell(c) for c in row])
+
+            if not rows:
+                story.append(Paragraph("<i>(empty sheet)</i>", styles["BodyText"]))
+            else:
+                # Cap dimensions so the PDF doesn't explode for huge sheets.
+                max_rows = 500
+                max_cols = 20
+                truncated_rows = rows[:max_rows]
+                truncated_rows = [r[:max_cols] for r in truncated_rows]
+
+                table = Table(truncated_rows, repeatRows=1)
+                table.setStyle(TableStyle([
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#1f4e79")),
+                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+                    ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                    ("FONTSIZE", (0, 0), (-1, -1), 8),
+                    ("GRID", (0, 0), (-1, -1), 0.25, colors.lightgrey),
+                    ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.whitesmoke, colors.white]),
+                    ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ]))
+                story.append(table)
+
+                if len(rows) > max_rows or any(len(r) > max_cols for r in rows):
+                    story.append(Spacer(1, 6))
+                    story.append(Paragraph(
+                        f"<i>Truncated to first {max_rows} rows × {max_cols} columns.</i>",
+                        styles["BodyText"],
+                    ))
+
+            if s_idx < len(wb.sheetnames) - 1:
+                story.append(PageBreak())
+
+        doc.build(story)
+    finally:
+        wb.close()
+
+    return str(output_file)
+
+
+def csv_to_xlsx(input_path: str, output_dir: str, delimiter: str = ",") -> str:
+    """Convert a CSV file into a single-sheet .xlsx workbook."""
+    input_file = Path(input_path)
+    output_file = Path(output_dir) / f"{input_file.stem}.xlsx"
+
+    delimiter = delimiter or ","
+    if len(delimiter) > 2:
+        raise ValueError("delimiter must be a single character (use ',' '\\t' ';' '|').")
+    if delimiter == "\\t":
+        delimiter = "\t"
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = input_file.stem[:31] or "Sheet1"
+
+    with input_file.open("r", encoding="utf-8-sig", newline="") as f:
+        reader = csv.reader(f, delimiter=delimiter)
+        for row in reader:
+            ws.append(row)
+
+    wb.save(output_file)
+    return str(output_file)
+
+
+def xlsx_to_csv(input_path: str, output_dir: str, sheet: str = None) -> str:
+    """Convert an .xlsx sheet to CSV. If `sheet` is None, uses the first sheet."""
+    input_file = Path(input_path)
+
+    wb = load_workbook(input_file, data_only=True, read_only=True)
+    try:
+        if sheet:
+            if sheet not in wb.sheetnames:
+                raise ValueError(f"Sheet '{sheet}' not found. Available: {wb.sheetnames}")
+            ws = wb[sheet]
+            sheet_label = sheet
+        else:
+            ws = wb[wb.sheetnames[0]]
+            sheet_label = wb.sheetnames[0]
+
+        # Sanitize sheet name for filename use.
+        safe_label = "".join(c for c in sheet_label if c.isalnum() or c in "-_") or "sheet"
+        output_file = Path(output_dir) / f"{input_file.stem}_{safe_label}.csv"
+
+        with output_file.open("w", encoding="utf-8", newline="") as f:
+            writer = csv.writer(f)
+            for row in ws.iter_rows(values_only=True):
+                writer.writerow([_sanitize_cell(c) for c in row])
+    finally:
+        wb.close()
+
+    return str(output_file)
+
+
+def merge_excel_files(input_paths: List[str], output_dir: str) -> str:
+    """Merge multiple .xlsx files into one workbook (each input sheet → one output sheet)."""
+    if not input_paths:
+        raise ValueError("No input files provided for merging.")
+    if len(input_paths) < 2:
+        raise ValueError("Provide at least two Excel files to merge.")
+
+    output_file = Path(output_dir) / f"merged_{uuid.uuid4().hex[:8]}.xlsx"
+    out_wb = Workbook()
+    # Remove the default empty sheet so we start clean.
+    default_sheet = out_wb.active
+    out_wb.remove(default_sheet)
+
+    used_names = set()
+
+    def unique_name(base: str) -> str:
+        base = (base or "Sheet")[:25]  # leave room for suffix
+        candidate = base
+        i = 1
+        while candidate in used_names or len(candidate) > 31:
+            i += 1
+            candidate = f"{base}_{i}"[:31]
+        used_names.add(candidate)
+        return candidate
+
+    for path in input_paths:
+        src = Path(path)
+        wb = load_workbook(src, data_only=True, read_only=True)
+        try:
+            for sheet_name in wb.sheetnames:
+                src_ws = wb[sheet_name]
+                target_name = unique_name(f"{src.stem}_{sheet_name}")
+                dst_ws = out_wb.create_sheet(target_name)
+                for row in src_ws.iter_rows(values_only=True):
+                    dst_ws.append(list(row))
+        finally:
+            wb.close()
+
+    if not out_wb.sheetnames:
+        # Edge case: every input was empty.
+        out_wb.create_sheet("Sheet1")
+
+    out_wb.save(output_file)
+    return str(output_file)

--- a/scripts/excel_utils.py
+++ b/scripts/excel_utils.py
@@ -99,10 +99,13 @@ def csv_to_xlsx(input_path: str, output_dir: str, delimiter: str = ",") -> str:
     output_file = Path(output_dir) / f"{input_file.stem}.xlsx"
 
     delimiter = delimiter or ","
-    if len(delimiter) > 2:
-        raise ValueError("delimiter must be a single character (use ',' '\\t' ';' '|').")
+    # Normalize the literal "\t" escape to a real tab BEFORE validating length,
+    # so a real two-char input like "||" is rejected with a clear ValueError
+    # instead of falling through to csv.reader and raising a raw TypeError.
     if delimiter == "\\t":
         delimiter = "\t"
+    if len(delimiter) != 1:
+        raise ValueError("delimiter must be a single character (use ',' '\\t' ';' '|').")
 
     wb = Workbook()
     ws = wb.active

--- a/scripts/image_utils.py
+++ b/scripts/image_utils.py
@@ -1,8 +1,9 @@
 """
 Image conversion utilities for File Forge.
 """
+import io
 from pathlib import Path
-from PIL import Image, ImageOps
+from PIL import Image, ImageOps, ImageDraw, ImageFont
 import pillow_heif
 
 # Register HEIF opener with Pillow
@@ -204,6 +205,178 @@ def crop_image(input_path: str, output_dir: str,
         
         cropped_img = img.crop((x, y, right, lower))
         cropped_img.save(output_file, "JPEG", quality=quality, optimize=True)
-    
+
+    return str(output_file)
+
+
+_FORMAT_EXT = {"jpg": "jpg", "jpeg": "jpg", "png": "png", "webp": "webp"}
+_FORMAT_PIL = {"jpg": "JPEG", "jpeg": "JPEG", "png": "PNG", "webp": "WEBP"}
+
+
+def _save_pil(img: Image.Image, output_file: Path, fmt: str, quality: int = 90) -> None:
+    """Save a PIL image in the chosen format with sane defaults."""
+    pil_fmt = _FORMAT_PIL[fmt]
+    if pil_fmt == "JPEG":
+        if img.mode != "RGB":
+            img = img.convert("RGB")
+        img.save(output_file, pil_fmt, quality=quality, optimize=True)
+    elif pil_fmt == "PNG":
+        img.save(output_file, pil_fmt, optimize=True)
+    else:  # WEBP
+        img.save(output_file, pil_fmt, quality=quality, method=6)
+
+
+def rotate_image(input_path: str, output_dir: str, angle: float, quality: int = 95) -> str:
+    """Rotate an image counter-clockwise by `angle` degrees (90/180/270 are lossless-friendly)."""
+    try:
+        angle = float(angle)
+    except (TypeError, ValueError):
+        raise ValueError("angle must be a number.")
+
+    input_file = Path(input_path)
+    fmt = (input_file.suffix.lower().lstrip(".") or "jpg")
+    if fmt not in _FORMAT_EXT:
+        fmt = "jpg"
+    output_file = Path(output_dir) / f"{input_file.stem}_rotated.{_FORMAT_EXT[fmt]}"
+
+    with Image.open(input_file) as img:
+        img = ImageOps.exif_transpose(img)
+        # expand=True so rotated bounds are not clipped.
+        rotated = img.rotate(angle, resample=Image.Resampling.BICUBIC, expand=True)
+        _save_pil(rotated, output_file, fmt, quality=quality)
+
+    return str(output_file)
+
+
+def compress_image(input_path: str, output_dir: str, quality: int = 70) -> dict:
+    """Re-encode an image at a lower quality (JPEG/WebP) or with optimize=True (PNG)."""
+    try:
+        quality = int(quality)
+    except (TypeError, ValueError):
+        raise ValueError("quality must be an integer.")
+    if not 1 <= quality <= 100:
+        raise ValueError("quality must be between 1 and 100.")
+
+    input_file = Path(input_path)
+    fmt = input_file.suffix.lower().lstrip(".")
+    if fmt not in _FORMAT_EXT:
+        fmt = "jpg"
+    output_file = Path(output_dir) / f"{input_file.stem}_compressed.{_FORMAT_EXT[fmt]}"
+
+    original_size = input_file.stat().st_size
+    with Image.open(input_file) as img:
+        img = ImageOps.exif_transpose(img)
+        _save_pil(img, output_file, fmt, quality=quality)
+
+    compressed_size = output_file.stat().st_size
+    reduction = max(0.0, (1 - compressed_size / original_size) * 100) if original_size else 0.0
+    return {
+        "output_path": str(output_file),
+        "original_size": original_size,
+        "compressed_size": compressed_size,
+        "reduction_pct": round(reduction, 1),
+    }
+
+
+def convert_image_format(input_path: str, output_dir: str, target_format: str, quality: int = 90) -> str:
+    """Convert an image to JPG/PNG/WebP."""
+    target_format = (target_format or "").lower()
+    if target_format not in _FORMAT_EXT:
+        raise ValueError("target_format must be one of: jpg, png, webp.")
+
+    input_file = Path(input_path)
+    output_file = Path(output_dir) / f"{input_file.stem}.{_FORMAT_EXT[target_format]}"
+
+    with Image.open(input_file) as img:
+        img = ImageOps.exif_transpose(img)
+        # PNG/WebP can keep alpha; JPEG cannot.
+        if target_format in ("jpg", "jpeg") and img.mode in ("RGBA", "LA", "P"):
+            img = img.convert("RGB")
+        elif target_format == "png" and img.mode == "P":
+            img = img.convert("RGBA")
+        _save_pil(img, output_file, target_format, quality=quality)
+
+    return str(output_file)
+
+
+def watermark_image(
+    input_path: str,
+    output_dir: str,
+    text: str,
+    position: str = "bottom-right",
+    opacity: float = 0.4,
+    color: str = "white",
+    quality: int = 95,
+) -> str:
+    """Stamp a text watermark on an image. position: top-left/top-right/center/bottom-left/bottom-right/diagonal."""
+    if not text or not text.strip():
+        raise ValueError("Watermark text cannot be empty.")
+    try:
+        opacity = float(opacity)
+    except (TypeError, ValueError):
+        raise ValueError("opacity must be a number between 0.05 and 1.0.")
+    if not 0.05 <= opacity <= 1.0:
+        raise ValueError("opacity must be between 0.05 and 1.0.")
+    if position not in ("top-left", "top-right", "center", "bottom-left", "bottom-right", "diagonal"):
+        raise ValueError("position must be one of: top-left, top-right, center, bottom-left, bottom-right, diagonal.")
+
+    color_map = {"white": (255, 255, 255), "black": (0, 0, 0), "red": (220, 30, 30), "blue": (30, 30, 220)}
+    rgb = color_map.get((color or "white").lower(), (255, 255, 255))
+    alpha = int(255 * opacity)
+
+    input_file = Path(input_path)
+    fmt = input_file.suffix.lower().lstrip(".")
+    if fmt not in _FORMAT_EXT:
+        fmt = "jpg"
+    output_file = Path(output_dir) / f"{input_file.stem}_watermarked.{_FORMAT_EXT[fmt]}"
+
+    with Image.open(input_file) as img:
+        img = ImageOps.exif_transpose(img).convert("RGBA")
+        w, h = img.size
+
+        # Pick a font size proportional to the smaller dimension.
+        font_size = max(20, int(min(w, h) / 20))
+        try:
+            font = ImageFont.truetype("arial.ttf", font_size)
+        except (OSError, IOError):
+            font = ImageFont.load_default()
+
+        overlay = Image.new("RGBA", img.size, (0, 0, 0, 0))
+        draw = ImageDraw.Draw(overlay)
+
+        # Measure text.
+        try:
+            bbox = draw.textbbox((0, 0), text, font=font)
+            tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]
+        except AttributeError:
+            tw, th = font.getsize(text)
+
+        margin = max(10, int(min(w, h) * 0.02))
+
+        if position == "diagonal":
+            # Render text on a transparent layer, rotate 30°, paste centered.
+            text_layer = Image.new("RGBA", (tw + 20, th + 20), (0, 0, 0, 0))
+            ImageDraw.Draw(text_layer).text((10, 10), text, font=font, fill=(*rgb, alpha))
+            rotated = text_layer.rotate(30, resample=Image.Resampling.BICUBIC, expand=True)
+            rx, ry = rotated.size
+            overlay.paste(rotated, ((w - rx) // 2, (h - ry) // 2), rotated)
+        else:
+            if position == "top-left":
+                pos = (margin, margin)
+            elif position == "top-right":
+                pos = (w - tw - margin, margin)
+            elif position == "center":
+                pos = ((w - tw) // 2, (h - th) // 2)
+            elif position == "bottom-left":
+                pos = (margin, h - th - margin)
+            else:  # bottom-right
+                pos = (w - tw - margin, h - th - margin)
+            draw.text(pos, text, font=font, fill=(*rgb, alpha))
+
+        composed = Image.alpha_composite(img, overlay)
+        if fmt in ("jpg", "jpeg"):
+            composed = composed.convert("RGB")
+        _save_pil(composed, output_file, fmt, quality=quality)
+
     return str(output_file)
 

--- a/scripts/pdf_utils.py
+++ b/scripts/pdf_utils.py
@@ -1,4 +1,5 @@
 import threading
+import uuid
 import pikepdf
 from pathlib import Path
 from pdf2docx import Converter
@@ -271,18 +272,246 @@ def pdf_to_docx(input_path: str, output_dir: str, password: str = None) -> str:
     """Converts PDF to DOCX using pdf2docx (Fast, Rule-based)."""
     input_file = Path(input_path)
     output_file = Path(output_dir) / f"{input_file.stem}.docx"
-    
-    # Handle encrypted PDFs
+
     decrypted_path, needs_cleanup = _get_decrypted_pdf_path(input_path, password)
-    
+
     try:
         cv = Converter(decrypted_path)
-        cv.convert(str(output_file))
+        try:
+            cv.convert(str(output_file), multi_processing=True)
+        except Exception:
+            # Some environments (e.g. spawn-only Windows workers) can't fork — fall back.
+            cv.convert(str(output_file))
         cv.close()
     finally:
         if needs_cleanup:
             Path(decrypted_path).unlink(missing_ok=True)
-    
+
+    return str(output_file)
+
+
+def merge_pdfs(input_paths: List[str], output_dir: str, passwords: List[str] = None) -> str:
+    """Merge multiple PDFs into a single PDF, in the given order."""
+    if not input_paths:
+        raise ValueError("No input files provided for merging.")
+    if len(input_paths) < 2:
+        raise ValueError("Provide at least two PDF files to merge.")
+
+    output_dir_path = Path(output_dir)
+    output_file = output_dir_path / f"merged_{uuid.uuid4().hex[:8]}.pdf"
+
+    cleanup_paths: List[str] = []
+    try:
+        merged = pikepdf.Pdf.new()
+        for idx, path in enumerate(input_paths):
+            pwd = passwords[idx] if passwords and idx < len(passwords) else None
+            decrypted_path, needs_cleanup = _get_decrypted_pdf_path(path, pwd, output_dir_path)
+            if needs_cleanup:
+                cleanup_paths.append(decrypted_path)
+            with pikepdf.open(decrypted_path) as src:
+                merged.pages.extend(src.pages)
+        merged.save(output_file)
+    finally:
+        for p in cleanup_paths:
+            Path(p).unlink(missing_ok=True)
+
+    return str(output_file)
+
+
+def add_watermark(
+    input_path: str,
+    output_dir: str,
+    text: str,
+    position: str = "diagonal",
+    opacity: float = 0.3,
+    password: str = None,
+) -> str:
+    """Stamp a text watermark on every page."""
+    if not text or not text.strip():
+        raise ValueError("Watermark text cannot be empty.")
+    try:
+        opacity = float(opacity)
+    except (TypeError, ValueError):
+        raise ValueError("Opacity must be a number between 0.1 and 1.0.")
+    if not 0.05 <= opacity <= 1.0:
+        raise ValueError("Opacity must be between 0.1 and 1.0.")
+    if position not in ("diagonal", "top", "center", "bottom"):
+        raise ValueError("Position must be one of: diagonal, top, center, bottom.")
+
+    input_file = Path(input_path)
+    output_file = Path(output_dir) / f"{input_file.stem}_watermarked.pdf"
+
+    decrypted_path, needs_cleanup = _get_decrypted_pdf_path(input_path, password)
+
+    try:
+        # Use PyMuPDF for the overlay — simpler cross-page-size handling than pikepdf overlays.
+        doc = fitz.open(decrypted_path)
+        try:
+            for page in doc:
+                rect = page.rect
+                # Pick a font size relative to page width.
+                font_size = max(24, int(rect.width / 12))
+                color = (0.5, 0.5, 0.5)
+
+                if position == "diagonal":
+                    # Diagonal stamp anchored at page center (PyMuPDF rotate= must be a
+                    # multiple of 90, so apply the 45° rotation via morph).
+                    point = fitz.Point(rect.width / 2, rect.height / 2)
+                    page.insert_text(
+                        point,
+                        text,
+                        fontname="helv",
+                        fontsize=font_size,
+                        color=color,
+                        fill_opacity=opacity,
+                        morph=(point, fitz.Matrix(1, 1).prerotate(45)),
+                    )
+                else:
+                    if position == "top":
+                        y = rect.height * 0.1
+                    elif position == "center":
+                        y = rect.height / 2
+                    else:  # bottom
+                        y = rect.height * 0.9
+                    # Rough horizontal centering.
+                    text_width = font_size * 0.5 * len(text)
+                    x = max(10, (rect.width - text_width) / 2)
+                    page.insert_text(
+                        fitz.Point(x, y),
+                        text,
+                        fontname="helv",
+                        fontsize=font_size,
+                        color=color,
+                        fill_opacity=opacity,
+                    )
+            doc.save(str(output_file), garbage=3, deflate=True)
+        finally:
+            doc.close()
+    finally:
+        if needs_cleanup:
+            Path(decrypted_path).unlink(missing_ok=True)
+
+    return str(output_file)
+
+
+def pdf_to_images_zip(
+    input_path: str,
+    output_dir: str,
+    dpi: int = 150,
+    fmt: str = "jpg",
+    password: str = None,
+) -> dict:
+    """Render every PDF page to an image and return a zip."""
+    import zipfile
+
+    try:
+        dpi = int(dpi)
+    except (TypeError, ValueError):
+        raise ValueError("DPI must be an integer.")
+    if dpi < 50 or dpi > 300:
+        raise ValueError("DPI must be between 50 and 300.")
+
+    fmt = (fmt or "jpg").lower()
+    if fmt not in ("jpg", "jpeg", "png"):
+        raise ValueError("Format must be jpg or png.")
+    file_ext = "jpg" if fmt in ("jpg", "jpeg") else "png"
+
+    input_file = Path(input_path)
+    output_file = Path(output_dir) / f"{input_file.stem}_pages.zip"
+
+    decrypted_path, needs_cleanup = _get_decrypted_pdf_path(input_path, password)
+
+    try:
+        doc = fitz.open(decrypted_path)
+        try:
+            page_count = len(doc)
+            with zipfile.ZipFile(output_file, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+                for i, page in enumerate(doc, start=1):
+                    pix = page.get_pixmap(dpi=dpi)
+                    if file_ext == "jpg":
+                        img_bytes = pix.tobytes("jpeg")
+                    else:
+                        img_bytes = pix.tobytes("png")
+                    zf.writestr(f"{input_file.stem}_page_{i:03d}.{file_ext}", img_bytes)
+                    pix = None
+        finally:
+            doc.close()
+    finally:
+        if needs_cleanup:
+            Path(decrypted_path).unlink(missing_ok=True)
+
+    return {"output_path": str(output_file), "page_count": page_count}
+
+
+def sign_pdf(
+    input_path: str,
+    signature_image_path: str,
+    output_dir: str,
+    page: int = 1,
+    x: float = 0.65,
+    y: float = 0.85,
+    width: float = 0.2,
+    password: str = None,
+) -> str:
+    """Stamp a signature image onto the chosen page.
+
+    x, y, width are normalized (0-1) relative to page size. (x, y) is the top-left
+    of the signature box.
+    """
+    try:
+        page = int(page)
+        x = float(x)
+        y = float(y)
+        width = float(width)
+    except (TypeError, ValueError):
+        raise ValueError("page must be an integer; x, y, width must be numbers.")
+    if page < 1:
+        raise ValueError("Page number must be >= 1.")
+    if not (0.0 <= x <= 1.0 and 0.0 <= y <= 1.0):
+        raise ValueError("x and y must be between 0 and 1.")
+    if not (0.05 <= width <= 1.0):
+        raise ValueError("width must be between 0.05 and 1.0.")
+    if not Path(signature_image_path).exists():
+        raise ValueError("Signature image not found.")
+
+    input_file = Path(input_path)
+    output_file = Path(output_dir) / f"{input_file.stem}_signed.pdf"
+
+    decrypted_path, needs_cleanup = _get_decrypted_pdf_path(input_path, password)
+
+    try:
+        doc = fitz.open(decrypted_path)
+        try:
+            if page > len(doc):
+                raise ValueError(f"Page {page} exceeds document page count ({len(doc)}).")
+
+            target_page = doc[page - 1]
+            rect = target_page.rect
+            box_w = rect.width * width
+            # Estimate height from image aspect ratio so the signature isn't squashed.
+            try:
+                from PIL import Image as PILImage
+                with PILImage.open(signature_image_path) as im:
+                    img_w, img_h = im.size
+                aspect = img_h / img_w if img_w else 0.4
+            except Exception:
+                aspect = 0.4
+            box_h = box_w * aspect
+
+            x0 = rect.width * x
+            y0 = rect.height * y
+            x1 = min(rect.width, x0 + box_w)
+            y1 = min(rect.height, y0 + box_h)
+            target_rect = fitz.Rect(x0, y0, x1, y1)
+
+            target_page.insert_image(target_rect, filename=signature_image_path, keep_proportion=True)
+            doc.save(str(output_file), garbage=3, deflate=True)
+        finally:
+            doc.close()
+    finally:
+        if needs_cleanup:
+            Path(decrypted_path).unlink(missing_ok=True)
+
     return str(output_file)
 
 def merge_docx_files(input_files: list, output_file: str) -> None:

--- a/scripts/pdf_utils.py
+++ b/scripts/pdf_utils.py
@@ -278,11 +278,16 @@ def pdf_to_docx(input_path: str, output_dir: str, password: str = None) -> str:
     try:
         cv = Converter(decrypted_path)
         try:
-            cv.convert(str(output_file), multi_processing=True)
-        except Exception:
-            # Some environments (e.g. spawn-only Windows workers) can't fork — fall back.
-            cv.convert(str(output_file))
-        cv.close()
+            try:
+                cv.convert(str(output_file), multi_processing=True)
+            except Exception:
+                # Some environments (e.g. spawn-only Windows workers) can't fork — fall back.
+                cv.convert(str(output_file))
+        finally:
+            # pdf2docx Converter holds the source PDF open via PyMuPDF until close()
+            # is called. Without this finally block, a failed convert() would leak
+            # the file handle and block cleanup on Windows.
+            cv.close()
     finally:
         if needs_cleanup:
             Path(decrypted_path).unlink(missing_ok=True)

--- a/scripts/ppt_utils.py
+++ b/scripts/ppt_utils.py
@@ -12,9 +12,10 @@ import io
 import uuid
 import zipfile
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from pptx import Presentation
+from pptx.slide import Slide
 from pptx.util import Emu
 from PIL import Image, ImageDraw, ImageFont
 from reportlab.pdfgen import canvas as rl_canvas
@@ -25,7 +26,7 @@ from reportlab.lib.utils import ImageReader
 _EMU_PER_PX = 9525
 
 
-def _emu_to_px(emu_value) -> int:
+def _emu_to_px(emu_value: Optional[int]) -> int:
     if emu_value is None:
         return 0
     return int(emu_value / _EMU_PER_PX)
@@ -40,7 +41,7 @@ def _try_font(size: int) -> ImageFont.FreeTypeFont:
     return ImageFont.load_default()
 
 
-def _render_slide_to_image(slide, slide_width_emu, slide_height_emu) -> Image.Image:
+def _render_slide_to_image(slide: Slide, slide_width_emu: Optional[int], slide_height_emu: Optional[int]) -> Image.Image:
     """Best-effort raster of one slide: solid white background, then text/images at their layout positions."""
     w_px = max(1, _emu_to_px(slide_width_emu))
     h_px = max(1, _emu_to_px(slide_height_emu))
@@ -155,8 +156,15 @@ def ppt_to_pdf(input_path: str, output_dir: str) -> str:
 def merge_pptx(input_paths: List[str], output_dir: str) -> str:
     """Merge multiple .pptx files by appending slides into the first deck.
 
-    Uses pptx-internal XML copy of slide parts. Works for typical decks; very theme-heavy
-    files may render slightly off because the destination master/theme is preserved.
+    LIMITATION: this implementation deep-copies shape XML only — it does NOT
+    copy referenced package parts (images, embedded charts, media) or remap
+    their relationship IDs. As a result, slides from non-first decks that
+    contain pictures/charts/media will render with broken references in the
+    merged file. Text-only and shape-only decks merge cleanly. A full-fidelity
+    merge would either need to walk r:id relationships and copy the underlying
+    parts into the destination package, or rebuild each shape via the
+    high-level python-pptx APIs (add_picture, add_chart, etc.). See PR
+    discussion for context.
     """
     if not input_paths:
         raise ValueError("No input files provided for merging.")

--- a/scripts/ppt_utils.py
+++ b/scripts/ppt_utils.py
@@ -1,0 +1,189 @@
+"""
+PowerPoint utilities for File Forge.
+
+Pure-Python implementations using python-pptx + Pillow + reportlab.
+
+NOTE: pure-Python PPT rendering is best-effort. Each slide is rendered onto a Pillow
+canvas using only text, basic shape positions, and image content from the .pptx XML.
+Animations, gradients, themes, SmartArt, and complex effects are NOT preserved.
+For pixel-perfect rendering, install LibreOffice and shell out to `soffice`.
+"""
+import io
+import uuid
+import zipfile
+from pathlib import Path
+from typing import List
+
+from pptx import Presentation
+from pptx.util import Emu
+from PIL import Image, ImageDraw, ImageFont
+from reportlab.pdfgen import canvas as rl_canvas
+from reportlab.lib.utils import ImageReader
+
+
+# Render slides at 96 DPI (1 EMU = 1/914400 inch -> 1 EMU = 96/914400 px = 1/9525 px).
+_EMU_PER_PX = 9525
+
+
+def _emu_to_px(emu_value) -> int:
+    if emu_value is None:
+        return 0
+    return int(emu_value / _EMU_PER_PX)
+
+
+def _try_font(size: int) -> ImageFont.FreeTypeFont:
+    for name in ("arial.ttf", "DejaVuSans.ttf", "Helvetica.ttf"):
+        try:
+            return ImageFont.truetype(name, size)
+        except (OSError, IOError):
+            continue
+    return ImageFont.load_default()
+
+
+def _render_slide_to_image(slide, slide_width_emu, slide_height_emu) -> Image.Image:
+    """Best-effort raster of one slide: solid white background, then text/images at their layout positions."""
+    w_px = max(1, _emu_to_px(slide_width_emu))
+    h_px = max(1, _emu_to_px(slide_height_emu))
+    img = Image.new("RGB", (w_px, h_px), "white")
+    draw = ImageDraw.Draw(img)
+
+    for shape in slide.shapes:
+        try:
+            x = _emu_to_px(shape.left or 0)
+            y = _emu_to_px(shape.top or 0)
+            sw = _emu_to_px(shape.width or 0)
+            sh = _emu_to_px(shape.height or 0)
+        except Exception:
+            x = y = sw = sh = 0
+
+        # Embedded picture — paste it at the shape rect.
+        try:
+            if shape.shape_type == 13 and hasattr(shape, "image"):  # MSO_SHAPE_TYPE.PICTURE = 13
+                pic_bytes = shape.image.blob
+                with Image.open(io.BytesIO(pic_bytes)) as pic:
+                    pic = pic.convert("RGB")
+                    if sw > 0 and sh > 0:
+                        pic = pic.resize((sw, sh), Image.Resampling.LANCZOS)
+                    img.paste(pic, (x, y))
+                continue
+        except Exception:
+            pass
+
+        # Text frame — render each paragraph at the shape position.
+        if shape.has_text_frame:
+            cur_y = y
+            for para in shape.text_frame.paragraphs:
+                text = "".join(run.text for run in para.runs) or para.text or ""
+                if not text.strip():
+                    cur_y += 24
+                    continue
+
+                # Pick a font size: use the first run's size if available, else 18pt.
+                font_size_pt = 18
+                if para.runs and para.runs[0].font.size is not None:
+                    font_size_pt = max(8, int(para.runs[0].font.size.pt))
+                font_px = max(10, int(font_size_pt * 1.33))  # pt -> px @ 96 DPI
+                font = _try_font(font_px)
+
+                color = (20, 20, 20)
+                try:
+                    if para.runs and para.runs[0].font.color and para.runs[0].font.color.rgb:
+                        rgb = para.runs[0].font.color.rgb
+                        color = (rgb[0], rgb[1], rgb[2])
+                except Exception:
+                    pass
+
+                draw.text((x, cur_y), text, font=font, fill=color)
+                cur_y += font_px + 6
+
+    return img
+
+
+def ppt_to_images_zip(input_path: str, output_dir: str, fmt: str = "png") -> dict:
+    """Render every slide of a .pptx as an image and return a zip."""
+    fmt = (fmt or "png").lower()
+    if fmt not in ("png", "jpg", "jpeg"):
+        raise ValueError("fmt must be png or jpg.")
+    pil_fmt = "PNG" if fmt == "png" else "JPEG"
+    file_ext = "png" if fmt == "png" else "jpg"
+
+    input_file = Path(input_path)
+    output_file = Path(output_dir) / f"{input_file.stem}_slides.zip"
+
+    prs = Presentation(str(input_file))
+    slide_count = len(prs.slides)
+
+    with zipfile.ZipFile(output_file, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for i, slide in enumerate(prs.slides, start=1):
+            img = _render_slide_to_image(slide, prs.slide_width, prs.slide_height)
+            buf = io.BytesIO()
+            if pil_fmt == "JPEG":
+                img.save(buf, pil_fmt, quality=88, optimize=True)
+            else:
+                img.save(buf, pil_fmt, optimize=True)
+            zf.writestr(f"{input_file.stem}_slide_{i:03d}.{file_ext}", buf.getvalue())
+
+    return {"output_path": str(output_file), "slide_count": slide_count}
+
+
+def ppt_to_pdf(input_path: str, output_dir: str) -> str:
+    """Render every slide as an image and assemble into a PDF."""
+    input_file = Path(input_path)
+    output_file = Path(output_dir) / f"{input_file.stem}.pdf"
+
+    prs = Presentation(str(input_file))
+    if not list(prs.slides):
+        raise ValueError("Presentation has no slides.")
+
+    # Use the slide dimensions in points (EMU/12700).
+    page_w_pt = (prs.slide_width or 9144000) / 12700
+    page_h_pt = (prs.slide_height or 6858000) / 12700
+
+    c = rl_canvas.Canvas(str(output_file), pagesize=(page_w_pt, page_h_pt))
+    for slide in prs.slides:
+        img = _render_slide_to_image(slide, prs.slide_width, prs.slide_height)
+        buf = io.BytesIO()
+        img.save(buf, "PNG", optimize=True)
+        buf.seek(0)
+        c.drawImage(ImageReader(buf), 0, 0, width=page_w_pt, height=page_h_pt)
+        c.showPage()
+    c.save()
+
+    return str(output_file)
+
+
+def merge_pptx(input_paths: List[str], output_dir: str) -> str:
+    """Merge multiple .pptx files by appending slides into the first deck.
+
+    Uses pptx-internal XML copy of slide parts. Works for typical decks; very theme-heavy
+    files may render slightly off because the destination master/theme is preserved.
+    """
+    if not input_paths:
+        raise ValueError("No input files provided for merging.")
+    if len(input_paths) < 2:
+        raise ValueError("Provide at least two PPTX files to merge.")
+
+    from copy import deepcopy
+    from lxml import etree
+
+    output_file = Path(output_dir) / f"merged_{uuid.uuid4().hex[:8]}.pptx"
+    base = Presentation(str(input_paths[0]))
+
+    for path in input_paths[1:]:
+        src = Presentation(str(path))
+        for slide in src.slides:
+            # Use the destination's first slide layout — best-effort to keep things rendering.
+            blank_layout = base.slide_layouts[6] if len(base.slide_layouts) > 6 else base.slide_layouts[0]
+            new_slide = base.slides.add_slide(blank_layout)
+
+            # Strip the placeholders the layout added so we don't double-stack content.
+            for shape in list(new_slide.shapes):
+                sp = shape._element
+                sp.getparent().remove(sp)
+
+            # Deep-copy each shape's XML from the source slide.
+            for shape in slide.shapes:
+                new_slide.shapes._spTree.insert_element_before(deepcopy(shape._element), "p:extLst")
+
+    base.save(output_file)
+    return str(output_file)

--- a/static/index.html
+++ b/static/index.html
@@ -467,7 +467,7 @@
 
                     <!-- Watermark image options -->
                     <div id="watermark-image-area" class="password-area hidden">
-                        <input type="text" id="watermark-image-text" placeholder="Watermark text">
+                        <input type="text" id="watermark-image-text" placeholder="Watermark text" aria-label="Watermark text">
                         <select id="watermark-image-position" aria-label="Position">
                             <option value="bottom-right" selected>Bottom right</option>
                             <option value="bottom-left">Bottom left</option>
@@ -565,7 +565,7 @@
 
                     <div id="csv-to-xlsx-area" class="password-area hidden">
                         <p class="helper-text">Delimiter (default comma):</p>
-                        <select id="csv-delimiter">
+                        <select id="csv-delimiter" aria-label="CSV delimiter">
                             <option value="," selected>Comma (,)</option>
                             <option value=";">Semicolon (;)</option>
                             <option value="\t">Tab</option>
@@ -575,7 +575,7 @@
                     </div>
 
                     <div id="xlsx-to-csv-area" class="password-area hidden">
-                        <input type="text" id="xlsx-sheet-name" placeholder="Sheet name (blank = first sheet)">
+                        <input type="text" id="xlsx-sheet-name" placeholder="Sheet name (blank = first sheet)" aria-label="XLSX sheet name">
                         <button id="process-xlsx-to-csv-btn" class="primary-btn">Export CSV</button>
                     </div>
 
@@ -654,7 +654,7 @@
 
                     <div id="ppt-to-images-area" class="password-area hidden">
                         <p class="helper-text">Image format:</p>
-                        <select id="ppt-images-format">
+                        <select id="ppt-images-format" aria-label="Image format">
                             <option value="png" selected>PNG</option>
                             <option value="jpg">JPG</option>
                         </select>

--- a/static/index.html
+++ b/static/index.html
@@ -56,22 +56,22 @@
                     <div class="badge">New</div>
                 </div>
 
-                <div class="tool-card disabled">
+                <div class="tool-card active" onclick="showDrillDown('excel')" role="button" tabindex="0">
                     <div class="icon-wrapper excel">
                         <i class="fas fa-file-excel"></i>
                     </div>
                     <h3>Excel Tools</h3>
-                    <p>Coming soon: Excel to PDF, CSV to XLSX conversion.</p>
-                    <div class="badge">Soon</div>
+                    <p>Excel → PDF, CSV ↔ XLSX, and merge workbooks.</p>
+                    <div class="badge">New</div>
                 </div>
 
-                <div class="tool-card disabled">
+                <div class="tool-card active" onclick="showDrillDown('ppt')" role="button" tabindex="0">
                     <div class="icon-wrapper ppt">
                         <i class="fas fa-file-powerpoint"></i>
                     </div>
                     <h3>PPT Tools</h3>
-                    <p>Coming soon: PDF to PPT, PPT compression.</p>
-                    <div class="badge">Soon</div>
+                    <p>PPT → PDF, PPT → Images, and merge presentations.</p>
+                    <div class="badge">New</div>
                 </div>
             </div>
         </section>
@@ -135,6 +135,34 @@
                                 <p>Shrink file size — no Acrobat Pro needed</p>
                             </div>
                         </div>
+                        <div class="action-card" id="merge-pdf-btn" role="button" tabindex="0">
+                            <i class="fas fa-object-group"></i>
+                            <div class="action-text">
+                                <h4>Merge PDFs <span class="free-badge">Paid on Adobe</span></h4>
+                                <p>Combine multiple PDFs into one</p>
+                            </div>
+                        </div>
+                        <div class="action-card" id="watermark-pdf-btn" role="button" tabindex="0">
+                            <i class="fas fa-stamp"></i>
+                            <div class="action-text">
+                                <h4>Add Watermark <span class="free-badge">Paid on Adobe</span></h4>
+                                <p>Stamp text across every page</p>
+                            </div>
+                        </div>
+                        <div class="action-card" id="to-images-pdf-btn" role="button" tabindex="0">
+                            <i class="fas fa-images"></i>
+                            <div class="action-text">
+                                <h4>PDF → JPG <span class="free-badge">Paid on Adobe</span></h4>
+                                <p>Render each page as an image (zip)</p>
+                            </div>
+                        </div>
+                        <div class="action-card" id="sign-pdf-btn" role="button" tabindex="0">
+                            <i class="fas fa-signature"></i>
+                            <div class="action-text">
+                                <h4>Sign PDF <span class="free-badge">Paid on Adobe</span></h4>
+                                <p>Stamp a signature image onto a page</p>
+                            </div>
+                        </div>
                     </div>
 
                     <!-- Compress PDF Options -->
@@ -187,6 +215,62 @@
                         <button id="process-extract-btn" class="primary-btn">Extract Pages</button>
                     </div>
 
+                    <!-- Merge PDFs Options -->
+                    <div id="merge-area" class="password-area hidden">
+                        <p class="helper-text">Select 2 or more PDFs (use the upload area above — multi-select enabled).</p>
+                        <input type="password" id="merge-passwords" placeholder="Passwords, comma-separated (optional)" aria-label="Merge passwords">
+                        <button id="process-merge-btn" class="primary-btn">Merge Now</button>
+                    </div>
+
+                    <!-- Watermark Options -->
+                    <div id="watermark-area" class="password-area hidden">
+                        <p class="helper-text">Watermark settings:</p>
+                        <input type="text" id="watermark-text" placeholder="Watermark text (e.g. DRAFT)" aria-label="Watermark text">
+                        <select id="watermark-position" aria-label="Watermark position">
+                            <option value="diagonal" selected>Diagonal</option>
+                            <option value="top">Top</option>
+                            <option value="center">Center</option>
+                            <option value="bottom">Bottom</option>
+                        </select>
+                        <label class="helper-text" for="watermark-opacity">Opacity: <span id="watermark-opacity-value">0.3</span></label>
+                        <input type="range" id="watermark-opacity" min="0.1" max="1" step="0.05" value="0.3">
+                        <input type="password" id="watermark-password" placeholder="PDF Password (optional)" aria-label="PDF Password">
+                        <button id="process-watermark-btn" class="primary-btn">Add Watermark</button>
+                    </div>
+
+                    <!-- PDF to Images Options -->
+                    <div id="to-images-area" class="password-area hidden">
+                        <p class="helper-text">Render every page to an image:</p>
+                        <select id="to-images-dpi" aria-label="DPI">
+                            <option value="72">72 DPI (small)</option>
+                            <option value="150" selected>150 DPI (balanced)</option>
+                            <option value="300">300 DPI (high quality)</option>
+                        </select>
+                        <select id="to-images-format" aria-label="Format">
+                            <option value="jpg" selected>JPG</option>
+                            <option value="png">PNG</option>
+                        </select>
+                        <input type="password" id="to-images-password" placeholder="PDF Password (optional)" aria-label="PDF Password">
+                        <button id="process-to-images-btn" class="primary-btn">Render Pages</button>
+                    </div>
+
+                    <!-- Sign PDF Options -->
+                    <div id="sign-area" class="password-area hidden">
+                        <p class="helper-text">Upload your signature image (PNG with transparency works best):</p>
+                        <input type="file" id="signature-image" accept="image/png,image/jpeg" aria-label="Signature image">
+                        <input type="number" id="sign-page" min="1" value="1" placeholder="Page number" aria-label="Page number">
+                        <select id="sign-position" aria-label="Signature position">
+                            <option value="bottom-right" selected>Bottom right</option>
+                            <option value="bottom-center">Bottom center</option>
+                            <option value="bottom-left">Bottom left</option>
+                            <option value="top-right">Top right</option>
+                        </select>
+                        <label class="helper-text" for="sign-width">Width: <span id="sign-width-value">20%</span></label>
+                        <input type="range" id="sign-width" min="0.05" max="0.6" step="0.01" value="0.2">
+                        <input type="password" id="sign-password" placeholder="PDF Password (optional)" aria-label="PDF Password">
+                        <button id="process-sign-btn" class="primary-btn">Sign PDF</button>
+                    </div>
+
                     <!-- Password Modal-style Input (inline) -->
                     <div id="password-input-area" class="password-area hidden">
                         <input type="password" id="pdf-password" placeholder="Enter PDF Password"
@@ -223,7 +307,7 @@
                         aria-label="Upload Image file">
                         <i class="fas fa-cloud-upload-alt upload-icon"></i>
                         <p>Drag & drop your HEIC file or <span class="browse-text">browse</span></p>
-                        <input type="file" id="image-file-input" accept=".heic,.heif" hidden>
+                        <input type="file" id="image-file-input" accept="image/*,.heic,.heif" hidden>
                         <div id="image-file-info" class="file-info hidden">
                             <i class="fas fa-image"></i>
                             <span id="image-filename-display">No file selected</span>
@@ -319,6 +403,89 @@
                                 <p>Apply cropping selection</p>
                             </div>
                         </div>
+
+                        <div class="action-card" id="rotate-image-btn" role="button" tabindex="0">
+                            <i class="fas fa-redo"></i>
+                            <div class="action-text">
+                                <h4>Rotate</h4>
+                                <p>Rotate by 90°, 180° or 270°</p>
+                            </div>
+                        </div>
+                        <div class="action-card" id="compress-image-btn" role="button" tabindex="0">
+                            <i class="fas fa-compress"></i>
+                            <div class="action-text">
+                                <h4>Compress</h4>
+                                <p>Reduce file size at chosen quality</p>
+                            </div>
+                        </div>
+                        <div class="action-card" id="convert-format-btn" role="button" tabindex="0">
+                            <i class="fas fa-exchange-alt"></i>
+                            <div class="action-text">
+                                <h4>Convert Format</h4>
+                                <p>JPG ↔ PNG ↔ WebP</p>
+                            </div>
+                        </div>
+                        <div class="action-card" id="watermark-image-btn" role="button" tabindex="0">
+                            <i class="fas fa-stamp"></i>
+                            <div class="action-text">
+                                <h4>Add Watermark</h4>
+                                <p>Stamp text on the image</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Rotate options -->
+                    <div id="rotate-image-area" class="password-area hidden">
+                        <p class="helper-text">Choose rotation angle:</p>
+                        <select id="rotate-angle" aria-label="Rotation angle">
+                            <option value="90">90° counter-clockwise</option>
+                            <option value="180">180°</option>
+                            <option value="270">270° (90° clockwise)</option>
+                        </select>
+                        <button id="process-rotate-image-btn" class="primary-btn">Rotate</button>
+                    </div>
+
+                    <!-- Compress image options -->
+                    <div id="compress-image-area" class="password-area hidden">
+                        <label class="helper-text" for="compress-image-quality">Quality: <span id="compress-image-quality-value">70</span></label>
+                        <input type="range" id="compress-image-quality" min="10" max="95" value="70">
+                        <button id="process-compress-image-btn" class="primary-btn">Compress</button>
+                    </div>
+
+                    <!-- Convert format options -->
+                    <div id="convert-format-area" class="password-area hidden">
+                        <p class="helper-text">Target format:</p>
+                        <select id="convert-target-format" aria-label="Target format">
+                            <option value="jpg">JPG</option>
+                            <option value="png">PNG</option>
+                            <option value="webp">WebP</option>
+                        </select>
+                        <label class="helper-text" for="convert-format-quality">Quality (jpg/webp): <span id="convert-format-quality-value">90</span></label>
+                        <input type="range" id="convert-format-quality" min="10" max="100" value="90">
+                        <button id="process-convert-format-btn" class="primary-btn">Convert</button>
+                    </div>
+
+                    <!-- Watermark image options -->
+                    <div id="watermark-image-area" class="password-area hidden">
+                        <input type="text" id="watermark-image-text" placeholder="Watermark text">
+                        <select id="watermark-image-position" aria-label="Position">
+                            <option value="bottom-right" selected>Bottom right</option>
+                            <option value="bottom-left">Bottom left</option>
+                            <option value="bottom-center">Bottom center</option>
+                            <option value="top-right">Top right</option>
+                            <option value="top-left">Top left</option>
+                            <option value="center">Center</option>
+                            <option value="diagonal">Diagonal</option>
+                        </select>
+                        <select id="watermark-image-color" aria-label="Color">
+                            <option value="white">White</option>
+                            <option value="black">Black</option>
+                            <option value="red">Red</option>
+                            <option value="blue">Blue</option>
+                        </select>
+                        <label class="helper-text" for="watermark-image-opacity">Opacity: <span id="watermark-image-opacity-value">0.4</span></label>
+                        <input type="range" id="watermark-image-opacity" min="0.05" max="1" step="0.05" value="0.4">
+                        <button id="process-watermark-image-btn" class="primary-btn">Add Watermark</button>
                     </div>
 
                     <div id="image-status-display" class="status-display hidden">
@@ -331,6 +498,184 @@
                         <h3>Process Complete!</h3>
                         <p id="image-result-message"></p>
                         <a id="image-download-link" href="#" class="primary-btn download-btn">
+                            <i class="fas fa-download"></i> Download File
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Excel Page -->
+        <section id="excel-page" class="view">
+            <nav class="breadcrumb">
+                <button onclick="showHome()" class="back-btn"><i class="fas fa-arrow-left"></i> Back to Home</button>
+            </nav>
+
+            <div class="drill-down-content">
+                <div class="file-selector-area">
+                    <div id="excel-drop-zone" class="drop-zone" role="button" tabindex="0" aria-label="Upload Excel/CSV file">
+                        <i class="fas fa-cloud-upload-alt upload-icon"></i>
+                        <p>Drag & drop your Excel/CSV or <span class="browse-text">browse</span></p>
+                        <input type="file" id="excel-file-input" accept=".xlsx,.xls,.csv" hidden>
+                        <div id="excel-file-info" class="file-info hidden">
+                            <i class="fas fa-file-excel"></i>
+                            <span id="excel-filename-display">No file selected</span>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="actions-panel">
+                    <h2>Select Action for Excel/CSV</h2>
+
+                    <div class="action-buttons">
+                        <div class="action-card" id="excel-to-pdf-btn" role="button" tabindex="0">
+                            <i class="fas fa-file-pdf"></i>
+                            <div class="action-text">
+                                <h4>Excel → PDF</h4>
+                                <p>Render every sheet as a styled table</p>
+                            </div>
+                        </div>
+                        <div class="action-card" id="csv-to-xlsx-btn" role="button" tabindex="0">
+                            <i class="fas fa-file-excel"></i>
+                            <div class="action-text">
+                                <h4>CSV → XLSX</h4>
+                                <p>Turn a CSV into a workbook</p>
+                            </div>
+                        </div>
+                        <div class="action-card" id="xlsx-to-csv-btn" role="button" tabindex="0">
+                            <i class="fas fa-file-csv"></i>
+                            <div class="action-text">
+                                <h4>XLSX → CSV</h4>
+                                <p>Export a sheet to CSV</p>
+                            </div>
+                        </div>
+                        <div class="action-card" id="merge-excel-btn" role="button" tabindex="0">
+                            <i class="fas fa-object-group"></i>
+                            <div class="action-text">
+                                <h4>Merge Workbooks</h4>
+                                <p>Combine multiple .xlsx files</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div id="excel-to-pdf-area" class="password-area hidden">
+                        <p class="helper-text">Best-effort layout — cell colors, merged cells, and charts are approximated.</p>
+                        <button id="process-excel-to-pdf-btn" class="primary-btn">Convert to PDF</button>
+                    </div>
+
+                    <div id="csv-to-xlsx-area" class="password-area hidden">
+                        <p class="helper-text">Delimiter (default comma):</p>
+                        <select id="csv-delimiter">
+                            <option value="," selected>Comma (,)</option>
+                            <option value=";">Semicolon (;)</option>
+                            <option value="\t">Tab</option>
+                            <option value="|">Pipe (|)</option>
+                        </select>
+                        <button id="process-csv-to-xlsx-btn" class="primary-btn">Convert to XLSX</button>
+                    </div>
+
+                    <div id="xlsx-to-csv-area" class="password-area hidden">
+                        <input type="text" id="xlsx-sheet-name" placeholder="Sheet name (blank = first sheet)">
+                        <button id="process-xlsx-to-csv-btn" class="primary-btn">Export CSV</button>
+                    </div>
+
+                    <div id="merge-excel-area" class="password-area hidden">
+                        <p class="helper-text">Select 2+ .xlsx files via the upload area above.</p>
+                        <button id="process-merge-excel-btn" class="primary-btn">Merge Now</button>
+                    </div>
+
+                    <div id="excel-status-display" class="status-display hidden">
+                        <div class="loader"></div>
+                        <p id="excel-status-text">Processing...</p>
+                    </div>
+
+                    <div id="excel-result-display" class="result-display hidden">
+                        <i class="fas fa-check-circle success-icon"></i>
+                        <h3>Process Complete!</h3>
+                        <p id="excel-result-message"></p>
+                        <a id="excel-download-link" href="#" class="primary-btn download-btn">
+                            <i class="fas fa-download"></i> Download File
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- PPT Page -->
+        <section id="ppt-page" class="view">
+            <nav class="breadcrumb">
+                <button onclick="showHome()" class="back-btn"><i class="fas fa-arrow-left"></i> Back to Home</button>
+            </nav>
+
+            <div class="drill-down-content">
+                <div class="file-selector-area">
+                    <div id="ppt-drop-zone" class="drop-zone" role="button" tabindex="0" aria-label="Upload PPTX file">
+                        <i class="fas fa-cloud-upload-alt upload-icon"></i>
+                        <p>Drag & drop your PPTX or <span class="browse-text">browse</span></p>
+                        <input type="file" id="ppt-file-input" accept=".pptx" hidden>
+                        <div id="ppt-file-info" class="file-info hidden">
+                            <i class="fas fa-file-powerpoint"></i>
+                            <span id="ppt-filename-display">No file selected</span>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="actions-panel">
+                    <h2>Select Action for PPTX</h2>
+
+                    <div class="action-buttons">
+                        <div class="action-card" id="ppt-to-pdf-btn" role="button" tabindex="0">
+                            <i class="fas fa-file-pdf"></i>
+                            <div class="action-text">
+                                <h4>PPT → PDF</h4>
+                                <p>Render slides into a PDF</p>
+                            </div>
+                        </div>
+                        <div class="action-card" id="ppt-to-images-btn" role="button" tabindex="0">
+                            <i class="fas fa-images"></i>
+                            <div class="action-text">
+                                <h4>PPT → Images</h4>
+                                <p>Each slide as PNG/JPG (zip)</p>
+                            </div>
+                        </div>
+                        <div class="action-card" id="merge-ppt-btn" role="button" tabindex="0">
+                            <i class="fas fa-object-group"></i>
+                            <div class="action-text">
+                                <h4>Merge PPTX</h4>
+                                <p>Combine multiple presentations</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div id="ppt-to-pdf-area" class="password-area hidden">
+                        <p class="helper-text">Best-effort layout — animations, gradients, and SmartArt are not preserved.</p>
+                        <button id="process-ppt-to-pdf-btn" class="primary-btn">Convert to PDF</button>
+                    </div>
+
+                    <div id="ppt-to-images-area" class="password-area hidden">
+                        <p class="helper-text">Image format:</p>
+                        <select id="ppt-images-format">
+                            <option value="png" selected>PNG</option>
+                            <option value="jpg">JPG</option>
+                        </select>
+                        <button id="process-ppt-to-images-btn" class="primary-btn">Render Slides</button>
+                    </div>
+
+                    <div id="merge-ppt-area" class="password-area hidden">
+                        <p class="helper-text">Select 2+ .pptx files via the upload area above.</p>
+                        <button id="process-merge-ppt-btn" class="primary-btn">Merge Now</button>
+                    </div>
+
+                    <div id="ppt-status-display" class="status-display hidden">
+                        <div class="loader"></div>
+                        <p id="ppt-status-text">Processing...</p>
+                    </div>
+
+                    <div id="ppt-result-display" class="result-display hidden">
+                        <i class="fas fa-check-circle success-icon"></i>
+                        <h3>Process Complete!</h3>
+                        <p id="ppt-result-message"></p>
+                        <a id="ppt-download-link" href="#" class="primary-btn download-btn">
                             <i class="fas fa-download"></i> Download File
                         </a>
                     </div>
@@ -394,6 +739,51 @@
                                 data-step-label="Compress PDF" data-step-icon="fa-file-archive" role="button" tabindex="0" aria-label="Add Compress PDF step to workflow">
                                 <i class="fas fa-file-archive"></i>
                                 <span>Compress PDF</span>
+                            </div>
+                            <div class="step-item" draggable="true" data-step-type="rotate_image"
+                                data-step-label="Rotate Image" data-step-icon="fa-redo" role="button" tabindex="0" aria-label="Add Rotate Image step">
+                                <i class="fas fa-redo"></i>
+                                <span>Rotate Image</span>
+                            </div>
+                            <div class="step-item" draggable="true" data-step-type="compress_image"
+                                data-step-label="Compress Image" data-step-icon="fa-compress" role="button" tabindex="0" aria-label="Add Compress Image step">
+                                <i class="fas fa-compress"></i>
+                                <span>Compress Image</span>
+                            </div>
+                            <div class="step-item" draggable="true" data-step-type="convert_image"
+                                data-step-label="Convert Image" data-step-icon="fa-exchange-alt" role="button" tabindex="0" aria-label="Add Convert Image step">
+                                <i class="fas fa-exchange-alt"></i>
+                                <span>Convert Image</span>
+                            </div>
+                            <div class="step-item" draggable="true" data-step-type="watermark_image"
+                                data-step-label="Watermark Image" data-step-icon="fa-stamp" role="button" tabindex="0" aria-label="Add Watermark Image step">
+                                <i class="fas fa-stamp"></i>
+                                <span>Watermark Image</span>
+                            </div>
+                            <div class="step-item" draggable="true" data-step-type="excel_to_pdf"
+                                data-step-label="Excel → PDF" data-step-icon="fa-file-pdf" role="button" tabindex="0" aria-label="Add Excel to PDF step">
+                                <i class="fas fa-file-pdf"></i>
+                                <span>Excel → PDF</span>
+                            </div>
+                            <div class="step-item" draggable="true" data-step-type="csv_to_xlsx"
+                                data-step-label="CSV → XLSX" data-step-icon="fa-file-excel" role="button" tabindex="0" aria-label="Add CSV to XLSX step">
+                                <i class="fas fa-file-excel"></i>
+                                <span>CSV → XLSX</span>
+                            </div>
+                            <div class="step-item" draggable="true" data-step-type="xlsx_to_csv"
+                                data-step-label="XLSX → CSV" data-step-icon="fa-file-csv" role="button" tabindex="0" aria-label="Add XLSX to CSV step">
+                                <i class="fas fa-file-csv"></i>
+                                <span>XLSX → CSV</span>
+                            </div>
+                            <div class="step-item" draggable="true" data-step-type="ppt_to_pdf"
+                                data-step-label="PPT → PDF" data-step-icon="fa-file-pdf" role="button" tabindex="0" aria-label="Add PPT to PDF step">
+                                <i class="fas fa-file-pdf"></i>
+                                <span>PPT → PDF</span>
+                            </div>
+                            <div class="step-item" draggable="true" data-step-type="ppt_to_images"
+                                data-step-label="PPT → Images" data-step-icon="fa-images" role="button" tabindex="0" aria-label="Add PPT to Images step">
+                                <i class="fas fa-images"></i>
+                                <span>PPT → Images</span>
                             </div>
                         </div>
                     </div>

--- a/static/script.js
+++ b/static/script.js
@@ -883,26 +883,16 @@ async function initCropper() {
     }
 }
 
-// Hook into existing handleImageFile to trigger cropper if in crop mode
+// Hook into existing handleImageFile to trigger cropper if in crop mode.
+// Wrap the original instead of replacing it — the original now handles a much
+// broader accept list (BMP/TIFF/GIF/etc.) and resets per-action option panels
+// via hideImageActionAreas(). Re-implementing it here previously regressed both.
 const originalHandleImageFile = handleImageFile;
 handleImageFile = function (file) {
-    // Call original logic
-    const validTypes = ['image/heic', 'image/heif', 'image/jpeg', 'image/png', 'image/webp'];
-    const validExts = ['.heic', '.heif', '.jpg', '.jpeg', '.png', '.webp'];
-    const ext = '.' + file.name.split('.').pop().toLowerCase();
-
-    if (!validTypes.includes(file.type) && !validExts.includes(ext)) {
-        alert('Please select a valid image file (HEIC, JPG, PNG).');
-        return;
-    }
-    selectedImageFile = file;
-    document.getElementById('image-filename-display').textContent = file.name;
-    document.getElementById('image-file-info').classList.remove('hidden');
-    document.getElementById('image-status-display').classList.add('hidden');
-    document.getElementById('image-result-display').classList.add('hidden');
-
-    // If currently in crop mode, init cropper
-    if (document.getElementById('mode-crop').checked) {
+    originalHandleImageFile(file);
+    // If the original rejected the file, selectedImageFile stays null.
+    if (!selectedImageFile) return;
+    if (document.getElementById('mode-crop')?.checked) {
         initCropper();
     }
 };
@@ -1154,8 +1144,8 @@ function addStepToWorkflow(type, label, icon) {
     workflowSteps.push(step);
     renderWorkflowSteps();
 
-    // If step needs config, open modal
-    if (type === 'remove_password' || type === 'resize_image' || type === 'compress_pdf') {
+    // If step needs config, open modal — keep this in sync with needsConfig().
+    if (needsConfig(type)) {
         openConfigModal(workflowSteps.length - 1);
     }
 }
@@ -1210,6 +1200,17 @@ function removeStep(index) {
     renderWorkflowSteps();
 }
 
+// Escape values destined for innerHTML attribute interpolation. Any string that
+// originated from a user-typed input (watermark text, sheet name, password) must
+// pass through this before being templated into an HTML string, otherwise a
+// payload like `"><img src=x onerror=alert(1)>` breaks out of the value="..."
+// attribute and executes script when the modal is re-opened.
+function escapeAttr(s) {
+    return String(s ?? '').replace(/[&<>"']/g, c => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+    }[c]));
+}
+
 function openConfigModal(index) {
     currentConfigStepIndex = index;
     const step = workflowSteps[index];
@@ -1223,7 +1224,7 @@ function openConfigModal(index) {
         body.innerHTML = `
             <label>
                 <span style="display:block; margin-bottom:0.5rem; color:var(--text-muted)">PDF Password</span>
-                <input type="password" id="config-password" placeholder="Enter password" value="${step.config.password || ''}">
+                <input type="password" id="config-password" placeholder="Enter password" value="${escapeAttr(step.config.password)}">
             </label>
         `;
     } else if (step.type === 'resize_image') {
@@ -1273,7 +1274,7 @@ function openConfigModal(index) {
         const pos = step.config.position || 'bottom-right';
         body.innerHTML = `
             <label><span style="display:block; margin-bottom:0.5rem; color:var(--text-muted)">Text</span>
-            <input type="text" id="config-wm-text" value="${step.config.text || ''}"></label>
+            <input type="text" id="config-wm-text" value="${escapeAttr(step.config.text)}"></label>
             <label><span style="display:block; margin:0.75rem 0 0.5rem; color:var(--text-muted)">Position</span>
             <select id="config-wm-position">
                 ${['top-left','top-right','center','bottom-left','bottom-right','diagonal']
@@ -1294,7 +1295,7 @@ function openConfigModal(index) {
     } else if (step.type === 'xlsx_to_csv') {
         body.innerHTML = `
             <label><span style="display:block; margin-bottom:0.5rem; color:var(--text-muted)">Sheet name (blank = first)</span>
-            <input type="text" id="config-sheet" value="${step.config.sheet || ''}"></label>`;
+            <input type="text" id="config-sheet" value="${escapeAttr(step.config.sheet)}"></label>`;
     } else if (step.type === 'ppt_to_images') {
         const f = step.config.fmt || 'png';
         body.innerHTML = `

--- a/static/script.js
+++ b/static/script.js
@@ -218,6 +218,14 @@ function setMergeMode(on) {
 function handleFiles(files) {
     const pdfs = files.filter(f => f.type === 'application/pdf');
     if (pdfs.length === 0) {
+        // Clear any prior selection so the UI doesn't keep an obsolete file in
+        // state (otherwise a follow-up "Merge Now" click would silently re-use
+        // the previously selected files).
+        selectedFiles = [];
+        selectedFile = null;
+        fileInput.value = '';
+        filenameDisplay.textContent = 'No file selected';
+        fileInfo.classList.add('hidden');
         alert('Please select PDF files.');
         return;
     }
@@ -1652,7 +1660,15 @@ const excelFileInfo = document.getElementById('excel-file-info');
 function handleExcelFiles(files) {
     if (excelFileInput.multiple) {
         const xlsxs = files.filter(f => f.name.toLowerCase().endsWith('.xlsx'));
-        if (xlsxs.length === 0) { alert('Please select .xlsx files.'); return; }
+        if (xlsxs.length === 0) {
+            selectedExcelFiles = [];
+            selectedExcelFile = null;
+            excelFileInput.value = '';
+            excelFilenameDisplay.textContent = 'No file selected';
+            excelFileInfo.classList.add('hidden');
+            alert('Please select .xlsx files.');
+            return;
+        }
         selectedExcelFiles = xlsxs;
         selectedExcelFile = xlsxs[0];
         excelFilenameDisplay.textContent = xlsxs.length === 1
@@ -1785,7 +1801,15 @@ const pptFileInfo = document.getElementById('ppt-file-info');
 function handlePptFiles(files) {
     if (pptFileInput.multiple) {
         const pptxs = files.filter(f => f.name.toLowerCase().endsWith('.pptx'));
-        if (pptxs.length === 0) { alert('Please select .pptx files.'); return; }
+        if (pptxs.length === 0) {
+            selectedPptFiles = [];
+            selectedPptFile = null;
+            pptFileInput.value = '';
+            pptFilenameDisplay.textContent = 'No file selected';
+            pptFileInfo.classList.add('hidden');
+            alert('Please select .pptx files.');
+            return;
+        }
         selectedPptFiles = pptxs;
         selectedPptFile = pptxs[0];
         pptFilenameDisplay.textContent = pptxs.length === 1

--- a/static/script.js
+++ b/static/script.js
@@ -108,6 +108,7 @@ function updateDownloadLink(element, filename) {
 // === End Authentication ===
 
 let selectedFile = null;
+let selectedFiles = [];
 let selectedImageFile = null;
 let currentTool = null;
 
@@ -117,6 +118,8 @@ function showDrillDown(tool) {
     let pageId;
     if (tool === 'pdf') pageId = 'pdf-page';
     else if (tool === 'image') pageId = 'image-page';
+    else if (tool === 'excel') pageId = 'excel-page';
+    else if (tool === 'ppt') pageId = 'ppt-page';
     else if (tool === 'workflow') pageId = 'workflow-page';
     else return;
 
@@ -135,6 +138,8 @@ function showHome() {
     let pageId;
     if (currentTool === 'pdf') pageId = 'pdf-page';
     else if (currentTool === 'image') pageId = 'image-page';
+    else if (currentTool === 'excel') pageId = 'excel-page';
+    else if (currentTool === 'ppt') pageId = 'ppt-page';
     else if (currentTool === 'workflow') pageId = 'workflow-page';
     else pageId = 'pdf-page';
 
@@ -160,7 +165,11 @@ dropZone.onclick = () => fileInput.click();
 
 fileInput.onchange = (e) => {
     if (e.target.files.length > 0) {
-        handleFile(e.target.files[0]);
+        if (fileInput.multiple) {
+            handleFiles(Array.from(e.target.files));
+        } else {
+            handleFile(e.target.files[0]);
+        }
     }
 };
 
@@ -177,7 +186,11 @@ dropZone.ondrop = (e) => {
     e.preventDefault();
     dropZone.classList.remove('drag-over');
     if (e.dataTransfer.files.length > 0) {
-        handleFile(e.dataTransfer.files[0]);
+        if (fileInput.multiple) {
+            handleFiles(Array.from(e.dataTransfer.files));
+        } else {
+            handleFile(e.dataTransfer.files[0]);
+        }
     }
 };
 
@@ -186,7 +199,35 @@ function hidePdfActionAreas() {
     document.getElementById('convert-password-area').classList.add('hidden');
     document.getElementById('extract-pages-area')?.classList.add('hidden');
     document.getElementById('compress-area')?.classList.add('hidden');
+    document.getElementById('merge-area')?.classList.add('hidden');
+    document.getElementById('watermark-area')?.classList.add('hidden');
+    document.getElementById('to-images-area')?.classList.add('hidden');
+    document.getElementById('sign-area')?.classList.add('hidden');
     document.getElementById('result-display').classList.add('hidden');
+}
+
+function setMergeMode(on) {
+    fileInput.multiple = !!on;
+    if (!on) {
+        selectedFiles = [];
+    } else {
+        selectedFile = null;
+    }
+}
+
+function handleFiles(files) {
+    const pdfs = files.filter(f => f.type === 'application/pdf');
+    if (pdfs.length === 0) {
+        alert('Please select PDF files.');
+        return;
+    }
+    selectedFiles = pdfs;
+    selectedFile = pdfs[0];
+    filenameDisplay.textContent = pdfs.length === 1
+        ? pdfs[0].name
+        : `${pdfs.length} files: ${pdfs.map(f => f.name).join(', ')}`;
+    fileInfo.classList.remove('hidden');
+    document.getElementById('status-display').classList.add('hidden');
 }
 
 function handleFile(file) {
@@ -209,27 +250,58 @@ function handleFile(file) {
 
 // Actions
 document.getElementById('remove-password-btn').onclick = () => {
+    setMergeMode(false);
     if (!selectedFile) { alert('Please select a file first.'); return; }
     hidePdfActionAreas();
     document.getElementById('password-input-area').classList.remove('hidden');
 };
 
 document.getElementById('convert-word-btn').onclick = () => {
+    setMergeMode(false);
     if (!selectedFile) { alert('Please select a file first.'); return; }
     hidePdfActionAreas();
     document.getElementById('convert-password-area').classList.remove('hidden');
 };
 
 document.getElementById('extract-pages-btn').onclick = () => {
+    setMergeMode(false);
     if (!selectedFile) { alert('Please select a file first.'); return; }
     hidePdfActionAreas();
     document.getElementById('extract-pages-area').classList.remove('hidden');
 };
 
 document.getElementById('compress-pdf-btn').onclick = () => {
+    setMergeMode(false);
     if (!selectedFile) { alert('Please select a file first.'); return; }
     hidePdfActionAreas();
     document.getElementById('compress-area').classList.remove('hidden');
+};
+
+document.getElementById('merge-pdf-btn').onclick = () => {
+    setMergeMode(true);
+    hidePdfActionAreas();
+    document.getElementById('merge-area').classList.remove('hidden');
+};
+
+document.getElementById('watermark-pdf-btn').onclick = () => {
+    setMergeMode(false);
+    if (!selectedFile) { alert('Please select a file first.'); return; }
+    hidePdfActionAreas();
+    document.getElementById('watermark-area').classList.remove('hidden');
+};
+
+document.getElementById('to-images-pdf-btn').onclick = () => {
+    setMergeMode(false);
+    if (!selectedFile) { alert('Please select a file first.'); return; }
+    hidePdfActionAreas();
+    document.getElementById('to-images-area').classList.remove('hidden');
+};
+
+document.getElementById('sign-pdf-btn').onclick = () => {
+    setMergeMode(false);
+    if (!selectedFile) { alert('Please select a file first.'); return; }
+    hidePdfActionAreas();
+    document.getElementById('sign-area').classList.remove('hidden');
 };
 
 document.getElementById('process-compress-btn').onclick = async () => {
@@ -313,6 +385,97 @@ document.getElementById('process-extract-btn').onclick = () => {
     }
 
     processAction('/api/pdf/extract-pages', 'Extracting selected pages...', formData);
+};
+
+document.getElementById('process-merge-btn').onclick = () => {
+    if (!selectedFiles || selectedFiles.length < 2) {
+        alert('Please select at least two PDF files in the upload area.');
+        return;
+    }
+    const passwords = document.getElementById('merge-passwords').value || '';
+    const formData = new FormData();
+    selectedFiles.forEach(f => formData.append('files', f));
+    if (passwords) formData.append('passwords', passwords);
+    processAction('/api/pdf/merge', `Merging ${selectedFiles.length} PDFs...`, formData);
+};
+
+const watermarkOpacityInput = document.getElementById('watermark-opacity');
+if (watermarkOpacityInput) {
+    watermarkOpacityInput.addEventListener('input', (e) => {
+        document.getElementById('watermark-opacity-value').textContent = e.target.value;
+    });
+}
+
+document.getElementById('process-watermark-btn').onclick = () => {
+    if (!selectedFile) { alert('Please select a file first.'); return; }
+    const text = document.getElementById('watermark-text').value.trim();
+    if (!text) { alert('Please enter watermark text.'); return; }
+    const position = document.getElementById('watermark-position').value;
+    const opacity = document.getElementById('watermark-opacity').value;
+    const password = document.getElementById('watermark-password').value;
+
+    const formData = new FormData();
+    formData.append('file', selectedFile);
+    formData.append('text', text);
+    formData.append('position', position);
+    formData.append('opacity', opacity);
+    if (password) formData.append('password', password);
+
+    processAction('/api/pdf/watermark', 'Adding watermark...', formData);
+};
+
+document.getElementById('process-to-images-btn').onclick = () => {
+    if (!selectedFile) { alert('Please select a file first.'); return; }
+    const dpi = document.getElementById('to-images-dpi').value;
+    const fmt = document.getElementById('to-images-format').value;
+    const password = document.getElementById('to-images-password').value;
+
+    const formData = new FormData();
+    formData.append('file', selectedFile);
+    formData.append('dpi', dpi);
+    formData.append('fmt', fmt);
+    if (password) formData.append('password', password);
+
+    processAction('/api/pdf/to-images', 'Rendering pages to images...', formData);
+};
+
+const signWidthInput = document.getElementById('sign-width');
+if (signWidthInput) {
+    signWidthInput.addEventListener('input', (e) => {
+        document.getElementById('sign-width-value').textContent =
+            Math.round(parseFloat(e.target.value) * 100) + '%';
+    });
+}
+
+const SIGN_POSITION_PRESETS = {
+    'top-right':      { x: 0.65, y: 0.05 },
+    'bottom-right':   { x: 0.65, y: 0.85 },
+    'bottom-center':  { x: 0.40, y: 0.85 },
+    'bottom-left':    { x: 0.05, y: 0.85 },
+};
+
+document.getElementById('process-sign-btn').onclick = () => {
+    if (!selectedFile) { alert('Please select a PDF file first.'); return; }
+    const sigInput = document.getElementById('signature-image');
+    const sigFile = sigInput?.files?.[0];
+    if (!sigFile) { alert('Please choose a signature image.'); return; }
+
+    const page = parseInt(document.getElementById('sign-page').value, 10) || 1;
+    const positionKey = document.getElementById('sign-position').value;
+    const preset = SIGN_POSITION_PRESETS[positionKey] || SIGN_POSITION_PRESETS['bottom-right'];
+    const width = document.getElementById('sign-width').value;
+    const password = document.getElementById('sign-password').value;
+
+    const formData = new FormData();
+    formData.append('file', selectedFile);
+    formData.append('signature', sigFile);
+    formData.append('page', page);
+    formData.append('x', preset.x);
+    formData.append('y', preset.y);
+    formData.append('width', width);
+    if (password) formData.append('password', password);
+
+    processAction('/api/pdf/sign', 'Adding signature...', formData);
 };
 
 async function processAction(url, text, formData = null) {
@@ -422,15 +585,21 @@ function showCompressResult(data) {
 
 function resetUI() {
     selectedFile = null;
+    selectedFiles = [];
     selectedImageFile = null;
     currentTool = null;
     fileInput.value = '';
+    fileInput.multiple = false;
     filenameDisplay.textContent = 'No file selected';
     fileInfo.classList.add('hidden');
     document.getElementById('password-input-area').classList.add('hidden');
     document.getElementById('convert-password-area').classList.add('hidden');
     document.getElementById('extract-pages-area')?.classList.add('hidden');
     document.getElementById('compress-area')?.classList.add('hidden');
+    document.getElementById('merge-area')?.classList.add('hidden');
+    document.getElementById('watermark-area')?.classList.add('hidden');
+    document.getElementById('to-images-area')?.classList.add('hidden');
+    document.getElementById('sign-area')?.classList.add('hidden');
     document.getElementById('status-display').classList.add('hidden');
     document.getElementById('result-display').classList.add('hidden');
     const extractInput = document.getElementById('extract-pages-input');
@@ -492,21 +661,25 @@ if (qualitySlider) {
 }
 
 function handleImageFile(file) {
-    const validTypes = ['image/heic', 'image/heif'];
-    const validExts = ['.heic', '.heif'];
+    const validExts = ['.heic', '.heif', '.jpg', '.jpeg', '.png', '.webp', '.bmp', '.tiff', '.tif', '.gif'];
     const ext = '.' + file.name.split('.').pop().toLowerCase();
 
-    if (!validTypes.includes(file.type) && !validExts.includes(ext)) {
-        alert('Please select a HEIC or HEIF file.');
+    if (!file.type.startsWith('image/') && !validExts.includes(ext)) {
+        alert('Please select an image file (HEIC, JPG, PNG, WebP, BMP, TIFF, GIF).');
         return;
     }
     selectedImageFile = file;
     imageFilenameDisplay.textContent = file.name;
     imageFileInfo.classList.remove('hidden');
 
-    // Reset displays
     document.getElementById('image-status-display').classList.add('hidden');
     document.getElementById('image-result-display').classList.add('hidden');
+    hideImageActionAreas();
+}
+
+function hideImageActionAreas() {
+    ['rotate-image-area', 'compress-image-area', 'convert-format-area', 'watermark-image-area']
+        .forEach(id => document.getElementById(id)?.classList.add('hidden'));
 }
 
 // Convert to JPEG
@@ -1017,7 +1190,11 @@ function renderWorkflowSteps() {
 }
 
 function needsConfig(type) {
-    return ['remove_password', 'resize_image', 'compress_pdf'].includes(type);
+    return [
+        'remove_password', 'resize_image', 'compress_pdf',
+        'rotate_image', 'compress_image', 'convert_image', 'watermark_image',
+        'csv_to_xlsx', 'xlsx_to_csv', 'ppt_to_images',
+    ].includes(type);
 }
 
 function removeStep(index) {
@@ -1060,6 +1237,64 @@ function openConfigModal(index) {
                 </select>
             </label>
         `;
+    } else if (step.type === 'rotate_image') {
+        const a = step.config.angle ?? 90;
+        body.innerHTML = `
+            <label><span style="display:block; margin-bottom:0.5rem; color:var(--text-muted)">Rotation angle</span>
+            <select id="config-angle">
+                <option value="90" ${a == 90 ? 'selected' : ''}>90°</option>
+                <option value="180" ${a == 180 ? 'selected' : ''}>180°</option>
+                <option value="270" ${a == 270 ? 'selected' : ''}>270°</option>
+            </select></label>`;
+    } else if (step.type === 'compress_image') {
+        body.innerHTML = `
+            <label><span style="display:block; margin-bottom:0.5rem; color:var(--text-muted)">Quality (1-100)</span>
+            <input type="number" id="config-quality" min="10" max="95" value="${step.config.quality ?? 70}"></label>`;
+    } else if (step.type === 'convert_image') {
+        const t = step.config.target_format || 'jpg';
+        body.innerHTML = `
+            <label><span style="display:block; margin-bottom:0.5rem; color:var(--text-muted)">Target format</span>
+            <select id="config-target-format">
+                <option value="jpg" ${t === 'jpg' ? 'selected' : ''}>JPG</option>
+                <option value="png" ${t === 'png' ? 'selected' : ''}>PNG</option>
+                <option value="webp" ${t === 'webp' ? 'selected' : ''}>WebP</option>
+            </select></label>
+            <label><span style="display:block; margin:0.75rem 0 0.5rem; color:var(--text-muted)">Quality</span>
+            <input type="number" id="config-quality" min="10" max="100" value="${step.config.quality ?? 90}"></label>`;
+    } else if (step.type === 'watermark_image') {
+        const pos = step.config.position || 'bottom-right';
+        body.innerHTML = `
+            <label><span style="display:block; margin-bottom:0.5rem; color:var(--text-muted)">Text</span>
+            <input type="text" id="config-wm-text" value="${step.config.text || ''}"></label>
+            <label><span style="display:block; margin:0.75rem 0 0.5rem; color:var(--text-muted)">Position</span>
+            <select id="config-wm-position">
+                ${['top-left','top-right','center','bottom-left','bottom-right','diagonal']
+                    .map(p => `<option value="${p}" ${p === pos ? 'selected' : ''}>${p}</option>`).join('')}
+            </select></label>
+            <label><span style="display:block; margin:0.75rem 0 0.5rem; color:var(--text-muted)">Opacity (0.05-1.0)</span>
+            <input type="number" id="config-wm-opacity" min="0.05" max="1" step="0.05" value="${step.config.opacity ?? 0.4}"></label>`;
+    } else if (step.type === 'csv_to_xlsx') {
+        const d = step.config.delimiter || ',';
+        body.innerHTML = `
+            <label><span style="display:block; margin-bottom:0.5rem; color:var(--text-muted)">Delimiter</span>
+            <select id="config-delimiter">
+                <option value="," ${d === ',' ? 'selected' : ''}>Comma</option>
+                <option value=";" ${d === ';' ? 'selected' : ''}>Semicolon</option>
+                <option value="\\t" ${d === '\\t' ? 'selected' : ''}>Tab</option>
+                <option value="|" ${d === '|' ? 'selected' : ''}>Pipe</option>
+            </select></label>`;
+    } else if (step.type === 'xlsx_to_csv') {
+        body.innerHTML = `
+            <label><span style="display:block; margin-bottom:0.5rem; color:var(--text-muted)">Sheet name (blank = first)</span>
+            <input type="text" id="config-sheet" value="${step.config.sheet || ''}"></label>`;
+    } else if (step.type === 'ppt_to_images') {
+        const f = step.config.fmt || 'png';
+        body.innerHTML = `
+            <label><span style="display:block; margin-bottom:0.5rem; color:var(--text-muted)">Image format</span>
+            <select id="config-fmt">
+                <option value="png" ${f === 'png' ? 'selected' : ''}>PNG</option>
+                <option value="jpg" ${f === 'jpg' ? 'selected' : ''}>JPG</option>
+            </select></label>`;
     }
 
     modal.classList.remove('hidden');
@@ -1081,6 +1316,23 @@ function saveStepConfig() {
         step.config.percentage = parseInt(document.getElementById('config-percentage').value) || 50;
     } else if (step.type === 'compress_pdf') {
         step.config.level = document.getElementById('config-compress-level').value;
+    } else if (step.type === 'rotate_image') {
+        step.config.angle = parseInt(document.getElementById('config-angle').value) || 90;
+    } else if (step.type === 'compress_image') {
+        step.config.quality = parseInt(document.getElementById('config-quality').value) || 70;
+    } else if (step.type === 'convert_image') {
+        step.config.target_format = document.getElementById('config-target-format').value;
+        step.config.quality = parseInt(document.getElementById('config-quality').value) || 90;
+    } else if (step.type === 'watermark_image') {
+        step.config.text = document.getElementById('config-wm-text').value;
+        step.config.position = document.getElementById('config-wm-position').value;
+        step.config.opacity = parseFloat(document.getElementById('config-wm-opacity').value) || 0.4;
+    } else if (step.type === 'csv_to_xlsx') {
+        step.config.delimiter = document.getElementById('config-delimiter').value;
+    } else if (step.type === 'xlsx_to_csv') {
+        step.config.sheet = document.getElementById('config-sheet').value;
+    } else if (step.type === 'ppt_to_images') {
+        step.config.fmt = document.getElementById('config-fmt').value;
     }
 
     closeConfigModal();
@@ -1287,7 +1539,360 @@ const originalResetUI = resetUI;
 resetUI = function () {
     originalResetUI();
     resetWorkflowUI();
+    selectedExcelFile = null;
+    selectedExcelFiles = [];
+    if (excelFileInput) { excelFileInput.value = ''; excelFileInput.multiple = false; }
+    if (excelFilenameDisplay) excelFilenameDisplay.textContent = 'No file selected';
+    document.getElementById('excel-file-info')?.classList.add('hidden');
+    hideExcelActionAreas();
+    document.getElementById('excel-status-display')?.classList.add('hidden');
+    document.getElementById('excel-result-display')?.classList.add('hidden');
+
+    selectedPptFile = null;
+    selectedPptFiles = [];
+    if (pptFileInput) { pptFileInput.value = ''; pptFileInput.multiple = false; }
+    if (pptFilenameDisplay) pptFilenameDisplay.textContent = 'No file selected';
+    document.getElementById('ppt-file-info')?.classList.add('hidden');
+    hidePptActionAreas();
+    document.getElementById('ppt-status-display')?.classList.add('hidden');
+    document.getElementById('ppt-result-display')?.classList.add('hidden');
 };
+
+// === Image Page: new feature handlers (rotate, compress, convert format, watermark) ===
+
+function showImageOptionPanel(id) {
+    if (!selectedImageFile) { alert('Please select an image first.'); return false; }
+    hideImageActionAreas();
+    document.getElementById(id).classList.remove('hidden');
+    return true;
+}
+
+document.getElementById('rotate-image-btn')?.addEventListener('click', () => {
+    showImageOptionPanel('rotate-image-area');
+});
+document.getElementById('compress-image-btn')?.addEventListener('click', () => {
+    showImageOptionPanel('compress-image-area');
+});
+document.getElementById('convert-format-btn')?.addEventListener('click', () => {
+    showImageOptionPanel('convert-format-area');
+});
+document.getElementById('watermark-image-btn')?.addEventListener('click', () => {
+    showImageOptionPanel('watermark-image-area');
+});
+
+const compressImgQ = document.getElementById('compress-image-quality');
+if (compressImgQ) compressImgQ.addEventListener('input', e => {
+    document.getElementById('compress-image-quality-value').textContent = e.target.value;
+});
+const convertFmtQ = document.getElementById('convert-format-quality');
+if (convertFmtQ) convertFmtQ.addEventListener('input', e => {
+    document.getElementById('convert-format-quality-value').textContent = e.target.value;
+});
+const wmImgOpacity = document.getElementById('watermark-image-opacity');
+if (wmImgOpacity) wmImgOpacity.addEventListener('input', e => {
+    document.getElementById('watermark-image-opacity-value').textContent = e.target.value;
+});
+
+document.getElementById('process-rotate-image-btn')?.addEventListener('click', () => {
+    if (!selectedImageFile) { alert('Please select an image first.'); return; }
+    const angle = document.getElementById('rotate-angle').value;
+    const fd = new FormData();
+    fd.append('file', selectedImageFile);
+    fd.append('angle', angle);
+    processImageAction('/api/image/rotate', `Rotating ${angle}°...`, fd);
+});
+
+document.getElementById('process-compress-image-btn')?.addEventListener('click', () => {
+    if (!selectedImageFile) { alert('Please select an image first.'); return; }
+    const quality = document.getElementById('compress-image-quality').value;
+    const fd = new FormData();
+    fd.append('file', selectedImageFile);
+    fd.append('quality', quality);
+    processImageAction('/api/image/compress', 'Compressing image...', fd);
+});
+
+document.getElementById('process-convert-format-btn')?.addEventListener('click', () => {
+    if (!selectedImageFile) { alert('Please select an image first.'); return; }
+    const target_format = document.getElementById('convert-target-format').value;
+    const quality = document.getElementById('convert-format-quality').value;
+    const fd = new FormData();
+    fd.append('file', selectedImageFile);
+    fd.append('target_format', target_format);
+    fd.append('quality', quality);
+    processImageAction('/api/image/convert', `Converting to ${target_format.toUpperCase()}...`, fd);
+});
+
+document.getElementById('process-watermark-image-btn')?.addEventListener('click', () => {
+    if (!selectedImageFile) { alert('Please select an image first.'); return; }
+    const text = document.getElementById('watermark-image-text').value.trim();
+    if (!text) { alert('Please enter watermark text.'); return; }
+    const position = document.getElementById('watermark-image-position').value;
+    const opacity = document.getElementById('watermark-image-opacity').value;
+    const color = document.getElementById('watermark-image-color').value;
+
+    const fd = new FormData();
+    fd.append('file', selectedImageFile);
+    fd.append('text', text);
+    fd.append('position', position);
+    fd.append('opacity', opacity);
+    fd.append('color', color);
+    processImageAction('/api/image/watermark', 'Adding watermark...', fd);
+});
+
+// === Excel Page ===
+
+let selectedExcelFile = null;
+let selectedExcelFiles = [];
+
+const excelDropZone = document.getElementById('excel-drop-zone');
+const excelFileInput = document.getElementById('excel-file-input');
+const excelFilenameDisplay = document.getElementById('excel-filename-display');
+const excelFileInfo = document.getElementById('excel-file-info');
+
+function handleExcelFiles(files) {
+    if (excelFileInput.multiple) {
+        const xlsxs = files.filter(f => f.name.toLowerCase().endsWith('.xlsx'));
+        if (xlsxs.length === 0) { alert('Please select .xlsx files.'); return; }
+        selectedExcelFiles = xlsxs;
+        selectedExcelFile = xlsxs[0];
+        excelFilenameDisplay.textContent = xlsxs.length === 1
+            ? xlsxs[0].name
+            : `${xlsxs.length} files: ${xlsxs.map(f => f.name).join(', ')}`;
+    } else {
+        selectedExcelFile = files[0];
+        selectedExcelFiles = [files[0]];
+        excelFilenameDisplay.textContent = files[0].name;
+    }
+    excelFileInfo.classList.remove('hidden');
+    document.getElementById('excel-status-display').classList.add('hidden');
+    document.getElementById('excel-result-display').classList.add('hidden');
+}
+
+if (excelDropZone) {
+    excelDropZone.onclick = () => excelFileInput.click();
+    excelFileInput.onchange = e => { if (e.target.files.length) handleExcelFiles(Array.from(e.target.files)); };
+    excelDropZone.ondragover = e => { e.preventDefault(); excelDropZone.classList.add('drag-over'); };
+    excelDropZone.ondragleave = () => excelDropZone.classList.remove('drag-over');
+    excelDropZone.ondrop = e => {
+        e.preventDefault();
+        excelDropZone.classList.remove('drag-over');
+        if (e.dataTransfer.files.length) handleExcelFiles(Array.from(e.dataTransfer.files));
+    };
+}
+
+function hideExcelActionAreas() {
+    ['excel-to-pdf-area', 'csv-to-xlsx-area', 'xlsx-to-csv-area', 'merge-excel-area']
+        .forEach(id => document.getElementById(id)?.classList.add('hidden'));
+    document.getElementById('excel-result-display')?.classList.add('hidden');
+}
+
+function setExcelMergeMode(on) {
+    if (excelFileInput) excelFileInput.multiple = !!on;
+    if (!on) selectedExcelFiles = [];
+}
+
+document.getElementById('excel-to-pdf-btn')?.addEventListener('click', () => {
+    setExcelMergeMode(false);
+    if (!selectedExcelFile) { alert('Please select a file.'); return; }
+    hideExcelActionAreas();
+    document.getElementById('excel-to-pdf-area').classList.remove('hidden');
+});
+document.getElementById('csv-to-xlsx-btn')?.addEventListener('click', () => {
+    setExcelMergeMode(false);
+    if (!selectedExcelFile) { alert('Please select a CSV file.'); return; }
+    hideExcelActionAreas();
+    document.getElementById('csv-to-xlsx-area').classList.remove('hidden');
+});
+document.getElementById('xlsx-to-csv-btn')?.addEventListener('click', () => {
+    setExcelMergeMode(false);
+    if (!selectedExcelFile) { alert('Please select a file.'); return; }
+    hideExcelActionAreas();
+    document.getElementById('xlsx-to-csv-area').classList.remove('hidden');
+});
+document.getElementById('merge-excel-btn')?.addEventListener('click', () => {
+    setExcelMergeMode(true);
+    hideExcelActionAreas();
+    document.getElementById('merge-excel-area').classList.remove('hidden');
+});
+
+async function processExcelAction(url, text, formData) {
+    const statusDisplay = document.getElementById('excel-status-display');
+    const statusText = document.getElementById('excel-status-text');
+    const resultDisplay = document.getElementById('excel-result-display');
+
+    statusDisplay.classList.remove('hidden');
+    statusText.textContent = text;
+    resultDisplay.classList.add('hidden');
+
+    try {
+        const response = await fetchWithAuth(url, { method: 'POST', body: formData });
+        if (response.ok) {
+            const data = await response.json();
+            resultDisplay.classList.remove('hidden');
+            document.getElementById('excel-result-message').textContent = `${data.message}: ${data.filename}`;
+            updateDownloadLink(document.getElementById('excel-download-link'), data.filename);
+        } else {
+            const data = await response.json().catch(() => ({ detail: 'Failed' }));
+            alert('Error: ' + (data.detail || 'Failed'));
+        }
+    } catch (e) {
+        alert('Error: ' + e.message);
+    } finally {
+        statusDisplay.classList.add('hidden');
+    }
+}
+
+document.getElementById('process-excel-to-pdf-btn')?.addEventListener('click', () => {
+    if (!selectedExcelFile) { alert('Please select a file.'); return; }
+    const fd = new FormData();
+    fd.append('file', selectedExcelFile);
+    processExcelAction('/api/excel/to-pdf', 'Converting Excel to PDF...', fd);
+});
+document.getElementById('process-csv-to-xlsx-btn')?.addEventListener('click', () => {
+    if (!selectedExcelFile) { alert('Please select a CSV file.'); return; }
+    const fd = new FormData();
+    fd.append('file', selectedExcelFile);
+    fd.append('delimiter', document.getElementById('csv-delimiter').value);
+    processExcelAction('/api/excel/csv-to-xlsx', 'Converting CSV to XLSX...', fd);
+});
+document.getElementById('process-xlsx-to-csv-btn')?.addEventListener('click', () => {
+    if (!selectedExcelFile) { alert('Please select an XLSX file.'); return; }
+    const fd = new FormData();
+    fd.append('file', selectedExcelFile);
+    const sheet = document.getElementById('xlsx-sheet-name').value.trim();
+    if (sheet) fd.append('sheet', sheet);
+    processExcelAction('/api/excel/xlsx-to-csv', 'Exporting CSV...', fd);
+});
+document.getElementById('process-merge-excel-btn')?.addEventListener('click', () => {
+    if (!selectedExcelFiles || selectedExcelFiles.length < 2) {
+        alert('Please select at least two .xlsx files.'); return;
+    }
+    const fd = new FormData();
+    selectedExcelFiles.forEach(f => fd.append('files', f));
+    processExcelAction('/api/excel/merge', `Merging ${selectedExcelFiles.length} workbooks...`, fd);
+});
+
+// === PPT Page ===
+
+let selectedPptFile = null;
+let selectedPptFiles = [];
+
+const pptDropZone = document.getElementById('ppt-drop-zone');
+const pptFileInput = document.getElementById('ppt-file-input');
+const pptFilenameDisplay = document.getElementById('ppt-filename-display');
+const pptFileInfo = document.getElementById('ppt-file-info');
+
+function handlePptFiles(files) {
+    if (pptFileInput.multiple) {
+        const pptxs = files.filter(f => f.name.toLowerCase().endsWith('.pptx'));
+        if (pptxs.length === 0) { alert('Please select .pptx files.'); return; }
+        selectedPptFiles = pptxs;
+        selectedPptFile = pptxs[0];
+        pptFilenameDisplay.textContent = pptxs.length === 1
+            ? pptxs[0].name
+            : `${pptxs.length} files: ${pptxs.map(f => f.name).join(', ')}`;
+    } else {
+        if (!files[0].name.toLowerCase().endsWith('.pptx')) {
+            alert('Please select a .pptx file.'); return;
+        }
+        selectedPptFile = files[0];
+        selectedPptFiles = [files[0]];
+        pptFilenameDisplay.textContent = files[0].name;
+    }
+    pptFileInfo.classList.remove('hidden');
+    document.getElementById('ppt-status-display').classList.add('hidden');
+    document.getElementById('ppt-result-display').classList.add('hidden');
+}
+
+if (pptDropZone) {
+    pptDropZone.onclick = () => pptFileInput.click();
+    pptFileInput.onchange = e => { if (e.target.files.length) handlePptFiles(Array.from(e.target.files)); };
+    pptDropZone.ondragover = e => { e.preventDefault(); pptDropZone.classList.add('drag-over'); };
+    pptDropZone.ondragleave = () => pptDropZone.classList.remove('drag-over');
+    pptDropZone.ondrop = e => {
+        e.preventDefault();
+        pptDropZone.classList.remove('drag-over');
+        if (e.dataTransfer.files.length) handlePptFiles(Array.from(e.dataTransfer.files));
+    };
+}
+
+function hidePptActionAreas() {
+    ['ppt-to-pdf-area', 'ppt-to-images-area', 'merge-ppt-area']
+        .forEach(id => document.getElementById(id)?.classList.add('hidden'));
+    document.getElementById('ppt-result-display')?.classList.add('hidden');
+}
+
+function setPptMergeMode(on) {
+    if (pptFileInput) pptFileInput.multiple = !!on;
+    if (!on) selectedPptFiles = [];
+}
+
+document.getElementById('ppt-to-pdf-btn')?.addEventListener('click', () => {
+    setPptMergeMode(false);
+    if (!selectedPptFile) { alert('Please select a PPTX file.'); return; }
+    hidePptActionAreas();
+    document.getElementById('ppt-to-pdf-area').classList.remove('hidden');
+});
+document.getElementById('ppt-to-images-btn')?.addEventListener('click', () => {
+    setPptMergeMode(false);
+    if (!selectedPptFile) { alert('Please select a PPTX file.'); return; }
+    hidePptActionAreas();
+    document.getElementById('ppt-to-images-area').classList.remove('hidden');
+});
+document.getElementById('merge-ppt-btn')?.addEventListener('click', () => {
+    setPptMergeMode(true);
+    hidePptActionAreas();
+    document.getElementById('merge-ppt-area').classList.remove('hidden');
+});
+
+async function processPptAction(url, text, formData) {
+    const statusDisplay = document.getElementById('ppt-status-display');
+    const statusText = document.getElementById('ppt-status-text');
+    const resultDisplay = document.getElementById('ppt-result-display');
+
+    statusDisplay.classList.remove('hidden');
+    statusText.textContent = text;
+    resultDisplay.classList.add('hidden');
+
+    try {
+        const response = await fetchWithAuth(url, { method: 'POST', body: formData });
+        if (response.ok) {
+            const data = await response.json();
+            resultDisplay.classList.remove('hidden');
+            document.getElementById('ppt-result-message').textContent = `${data.message}: ${data.filename}`;
+            updateDownloadLink(document.getElementById('ppt-download-link'), data.filename);
+        } else {
+            const data = await response.json().catch(() => ({ detail: 'Failed' }));
+            alert('Error: ' + (data.detail || 'Failed'));
+        }
+    } catch (e) {
+        alert('Error: ' + e.message);
+    } finally {
+        statusDisplay.classList.add('hidden');
+    }
+}
+
+document.getElementById('process-ppt-to-pdf-btn')?.addEventListener('click', () => {
+    if (!selectedPptFile) { alert('Please select a PPTX file.'); return; }
+    const fd = new FormData();
+    fd.append('file', selectedPptFile);
+    processPptAction('/api/ppt/to-pdf', 'Converting PPT to PDF...', fd);
+});
+document.getElementById('process-ppt-to-images-btn')?.addEventListener('click', () => {
+    if (!selectedPptFile) { alert('Please select a PPTX file.'); return; }
+    const fd = new FormData();
+    fd.append('file', selectedPptFile);
+    fd.append('fmt', document.getElementById('ppt-images-format').value);
+    processPptAction('/api/ppt/to-images', 'Rendering slides...', fd);
+});
+document.getElementById('process-merge-ppt-btn')?.addEventListener('click', () => {
+    if (!selectedPptFiles || selectedPptFiles.length < 2) {
+        alert('Please select at least two .pptx files.'); return;
+    }
+    const fd = new FormData();
+    selectedPptFiles.forEach(f => fd.append('files', f));
+    processPptAction('/api/ppt/merge', `Merging ${selectedPptFiles.length} presentations...`, fd);
+});
 
 // Global Accessibility: Handle keyboard activation for role="button"
 document.addEventListener('keydown', (e) => {

--- a/tests/test_new_image_excel_ppt.py
+++ b/tests/test_new_image_excel_ppt.py
@@ -180,6 +180,24 @@ def test_csv_to_xlsx_roundtrip(csv_file, tmp_path):
     assert rows[1][0] == "alice"
 
 
+def test_csv_to_xlsx_rejects_multichar_delimiter(csv_file, tmp_path):
+    # "||" used to slip past the old `len > 2` check and reach csv.reader,
+    # which raised a raw TypeError. Now it must raise a clear ValueError.
+    with pytest.raises(ValueError, match="single character"):
+        csv_to_xlsx(str(csv_file), str(tmp_path), delimiter="||")
+
+
+def test_csv_to_xlsx_normalizes_tab_escape(tmp_path):
+    p = tmp_path / "tabbed.csv"
+    p.write_text("a\tb\n1\t2\n", encoding="utf-8")
+    out = Path(csv_to_xlsx(str(p), str(tmp_path), delimiter="\\t"))
+    assert out.exists()
+    wb = load_workbook(out)
+    rows = list(wb.active.iter_rows(values_only=True))
+    assert rows[0] == ("a", "b")
+    assert rows[1] == ("1", "2")
+
+
 def test_xlsx_to_csv_first_sheet(xlsx_file, tmp_path):
     out = Path(xlsx_to_csv(str(xlsx_file), str(tmp_path)))
     assert out.exists()

--- a/tests/test_new_image_excel_ppt.py
+++ b/tests/test_new_image_excel_ppt.py
@@ -1,0 +1,249 @@
+import csv
+import zipfile
+from pathlib import Path
+
+import pytest
+from openpyxl import Workbook, load_workbook
+from PIL import Image
+from pptx import Presentation
+from pptx.util import Inches, Pt
+
+from scripts.excel_utils import (
+    csv_to_xlsx,
+    excel_to_pdf,
+    merge_excel_files,
+    xlsx_to_csv,
+)
+from scripts.image_utils import (
+    compress_image,
+    convert_image_format,
+    rotate_image,
+    watermark_image,
+)
+from scripts.ppt_utils import merge_pptx, ppt_to_images_zip, ppt_to_pdf
+
+
+# --- Fixtures ---
+
+@pytest.fixture
+def jpeg_image(tmp_path):
+    p = tmp_path / "in.jpg"
+    Image.new("RGB", (200, 100), color=(120, 80, 200)).save(p, "JPEG", quality=95)
+    return p
+
+
+@pytest.fixture
+def png_image(tmp_path):
+    p = tmp_path / "in.png"
+    Image.new("RGBA", (160, 120), color=(255, 0, 0, 200)).save(p, "PNG")
+    return p
+
+
+@pytest.fixture
+def csv_file(tmp_path):
+    p = tmp_path / "data.csv"
+    with p.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["name", "age", "city"])
+        w.writerow(["alice", 30, "NYC"])
+        w.writerow(["bob", 28, "SF"])
+    return p
+
+
+@pytest.fixture
+def xlsx_file(tmp_path):
+    p = tmp_path / "data.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "People"
+    ws.append(["name", "age"])
+    ws.append(["alice", 30])
+    ws.append(["bob", 28])
+    wb.save(p)
+    return p
+
+
+@pytest.fixture
+def two_xlsx_files(tmp_path):
+    paths = []
+    for i in range(2):
+        p = tmp_path / f"book_{i}.xlsx"
+        wb = Workbook()
+        ws = wb.active
+        ws.title = f"Sheet_{i}"
+        ws.append([f"file{i}_a", f"file{i}_b"])
+        ws.append([1, 2])
+        wb.save(p)
+        paths.append(p)
+    return paths
+
+
+@pytest.fixture
+def pptx_file(tmp_path):
+    p = tmp_path / "deck.pptx"
+    prs = Presentation()
+    for i in range(2):
+        slide = prs.slides.add_slide(prs.slide_layouts[5])  # title only
+        title = slide.shapes.title
+        title.text = f"Slide {i + 1}"
+        # Add a freeform text box.
+        tx = slide.shapes.add_textbox(Inches(1), Inches(2), Inches(4), Inches(1))
+        tf = tx.text_frame
+        tf.text = f"Body text {i + 1}"
+        for run in tf.paragraphs[0].runs:
+            run.font.size = Pt(20)
+    prs.save(p)
+    return p
+
+
+@pytest.fixture
+def two_pptx_files(tmp_path):
+    paths = []
+    for i in range(2):
+        p = tmp_path / f"deck_{i}.pptx"
+        prs = Presentation()
+        slide = prs.slides.add_slide(prs.slide_layouts[5])
+        slide.shapes.title.text = f"Deck {i} slide"
+        prs.save(p)
+        paths.append(p)
+    return paths
+
+
+# --- Image tests ---
+
+def test_rotate_image_90_swaps_dimensions(jpeg_image, tmp_path):
+    out = Path(rotate_image(str(jpeg_image), str(tmp_path), 90))
+    assert out.exists()
+    with Image.open(out) as img:
+        assert img.size == (100, 200)
+
+
+def test_rotate_image_rejects_bad_angle(jpeg_image, tmp_path):
+    with pytest.raises(ValueError):
+        rotate_image(str(jpeg_image), str(tmp_path), "abc")
+
+
+def test_compress_image_reduces_size(jpeg_image, tmp_path):
+    # Make the image a real photo-like one so JPEG q=10 actually compresses.
+    big = tmp_path / "big.jpg"
+    Image.new("RGB", (800, 800), (200, 100, 50)).save(big, "JPEG", quality=95)
+    result = compress_image(str(big), str(tmp_path), quality=10)
+    assert Path(result["output_path"]).exists()
+    assert result["compressed_size"] <= result["original_size"]
+
+
+def test_compress_image_rejects_bad_quality(jpeg_image, tmp_path):
+    with pytest.raises(ValueError):
+        compress_image(str(jpeg_image), str(tmp_path), quality=200)
+
+
+def test_convert_image_to_png(jpeg_image, tmp_path):
+    out = Path(convert_image_format(str(jpeg_image), str(tmp_path), "png"))
+    assert out.exists()
+    assert out.suffix == ".png"
+    with Image.open(out) as img:
+        assert img.format == "PNG"
+
+
+def test_convert_image_to_webp(png_image, tmp_path):
+    out = Path(convert_image_format(str(png_image), str(tmp_path), "webp"))
+    assert out.exists()
+    assert out.suffix == ".webp"
+
+
+def test_convert_image_rejects_bad_format(jpeg_image, tmp_path):
+    with pytest.raises(ValueError):
+        convert_image_format(str(jpeg_image), str(tmp_path), "tiff")
+
+
+def test_watermark_image_creates_output(jpeg_image, tmp_path):
+    out = Path(watermark_image(str(jpeg_image), str(tmp_path), "DRAFT", position="diagonal"))
+    assert out.exists()
+    with Image.open(out) as img:
+        assert img.size == (200, 100)
+
+
+def test_watermark_image_rejects_empty_text(jpeg_image, tmp_path):
+    with pytest.raises(ValueError):
+        watermark_image(str(jpeg_image), str(tmp_path), "  ")
+
+
+# --- Excel tests ---
+
+def test_csv_to_xlsx_roundtrip(csv_file, tmp_path):
+    out = Path(csv_to_xlsx(str(csv_file), str(tmp_path)))
+    assert out.exists()
+    wb = load_workbook(out)
+    ws = wb.active
+    rows = list(ws.iter_rows(values_only=True))
+    assert rows[0] == ("name", "age", "city")
+    assert rows[1][0] == "alice"
+
+
+def test_xlsx_to_csv_first_sheet(xlsx_file, tmp_path):
+    out = Path(xlsx_to_csv(str(xlsx_file), str(tmp_path)))
+    assert out.exists()
+    text = out.read_text(encoding="utf-8")
+    assert "name,age" in text
+    assert "alice,30" in text
+
+
+def test_xlsx_to_csv_named_sheet(xlsx_file, tmp_path):
+    out = Path(xlsx_to_csv(str(xlsx_file), str(tmp_path), sheet="People"))
+    assert out.exists()
+
+
+def test_xlsx_to_csv_unknown_sheet(xlsx_file, tmp_path):
+    with pytest.raises(ValueError):
+        xlsx_to_csv(str(xlsx_file), str(tmp_path), sheet="Nope")
+
+
+def test_excel_to_pdf_creates_pdf(xlsx_file, tmp_path):
+    out = Path(excel_to_pdf(str(xlsx_file), str(tmp_path)))
+    assert out.exists()
+    assert out.suffix == ".pdf"
+    assert out.stat().st_size > 0
+
+
+def test_merge_excel_combines_sheets(two_xlsx_files, tmp_path):
+    out = Path(merge_excel_files([str(p) for p in two_xlsx_files], str(tmp_path)))
+    assert out.exists()
+    wb = load_workbook(out)
+    # Each input had one sheet -> output has 2.
+    assert len(wb.sheetnames) == 2
+
+
+def test_merge_excel_requires_two(xlsx_file, tmp_path):
+    with pytest.raises(ValueError):
+        merge_excel_files([str(xlsx_file)], str(tmp_path))
+
+
+# --- PPT tests ---
+
+def test_ppt_to_images_zip_one_per_slide(pptx_file, tmp_path):
+    result = ppt_to_images_zip(str(pptx_file), str(tmp_path), fmt="png")
+    out = Path(result["output_path"])
+    assert out.exists()
+    assert result["slide_count"] == 2
+    with zipfile.ZipFile(out) as zf:
+        assert len(zf.namelist()) == 2
+
+
+def test_ppt_to_pdf_creates_pdf(pptx_file, tmp_path):
+    out = Path(ppt_to_pdf(str(pptx_file), str(tmp_path)))
+    assert out.exists()
+    assert out.suffix == ".pdf"
+    assert out.stat().st_size > 0
+
+
+def test_merge_pptx_combines_decks(two_pptx_files, tmp_path):
+    out = Path(merge_pptx([str(p) for p in two_pptx_files], str(tmp_path)))
+    assert out.exists()
+    prs = Presentation(str(out))
+    # Original first deck has 1 slide; appending the second deck's 1 slide -> 2 total.
+    assert len(prs.slides) == 2
+
+
+def test_merge_pptx_requires_two(pptx_file, tmp_path):
+    with pytest.raises(ValueError):
+        merge_pptx([str(pptx_file)], str(tmp_path))

--- a/tests/test_pdf_new_features.py
+++ b/tests/test_pdf_new_features.py
@@ -1,0 +1,111 @@
+import zipfile
+from pathlib import Path
+
+import pikepdf
+import pytest
+from PIL import Image
+from reportlab.pdfgen import canvas
+
+from scripts.pdf_utils import (
+    add_watermark,
+    merge_pdfs,
+    pdf_to_images_zip,
+    sign_pdf,
+)
+
+
+@pytest.fixture
+def two_pdfs(tmp_path):
+    paths = []
+    for i in range(2):
+        p = tmp_path / f"src_{i}.pdf"
+        c = canvas.Canvas(str(p))
+        c.drawString(100, 750, f"file {i} page 1")
+        c.showPage()
+        c.drawString(100, 750, f"file {i} page 2")
+        c.save()
+        paths.append(p)
+    return paths
+
+
+@pytest.fixture
+def signature_png(tmp_path):
+    p = tmp_path / "sig.png"
+    Image.new("RGBA", (200, 80), (0, 0, 0, 0)).save(p, "PNG")
+    return p
+
+
+def test_merge_pdfs_combines_page_counts(two_pdfs, tmp_path):
+    out_str = merge_pdfs([str(p) for p in two_pdfs], str(tmp_path))
+    out = Path(out_str)
+    assert out.exists()
+    with pikepdf.open(out) as pdf:
+        assert len(pdf.pages) == 4
+
+
+def test_merge_pdfs_requires_two(sample_pdf, tmp_path):
+    with pytest.raises(ValueError):
+        merge_pdfs([str(sample_pdf)], str(tmp_path))
+
+
+def test_add_watermark_creates_valid_pdf(multi_page_pdf, tmp_path):
+    out_str = add_watermark(str(multi_page_pdf), str(tmp_path), "DRAFT")
+    out = Path(out_str)
+    assert out.exists()
+    with pikepdf.open(out) as pdf:
+        assert len(pdf.pages) == 4
+
+
+def test_add_watermark_rejects_empty_text(sample_pdf, tmp_path):
+    with pytest.raises(ValueError):
+        add_watermark(str(sample_pdf), str(tmp_path), "  ")
+
+
+def test_add_watermark_rejects_bad_position(sample_pdf, tmp_path):
+    with pytest.raises(ValueError):
+        add_watermark(str(sample_pdf), str(tmp_path), "X", position="sideways")
+
+
+def test_pdf_to_images_zip_one_image_per_page(multi_page_pdf, tmp_path):
+    result = pdf_to_images_zip(str(multi_page_pdf), str(tmp_path), dpi=72)
+    out = Path(result["output_path"])
+    assert out.exists()
+    assert result["page_count"] == 4
+    with zipfile.ZipFile(out) as zf:
+        names = zf.namelist()
+    assert len(names) == 4
+    assert all(n.endswith(".jpg") for n in names)
+
+
+def test_pdf_to_images_zip_rejects_bad_dpi(sample_pdf, tmp_path):
+    with pytest.raises(ValueError):
+        pdf_to_images_zip(str(sample_pdf), str(tmp_path), dpi=10)
+    with pytest.raises(ValueError):
+        pdf_to_images_zip(str(sample_pdf), str(tmp_path), dpi=1000)
+
+
+def test_sign_pdf_inserts_image(multi_page_pdf, signature_png, tmp_path):
+    import fitz
+
+    with fitz.open(str(multi_page_pdf)) as src:
+        page1_images_before = len(src[0].get_images(full=True))
+
+    out_str = sign_pdf(
+        str(multi_page_pdf), str(signature_png), str(tmp_path),
+        page=1, x=0.65, y=0.85, width=0.2,
+    )
+    out = Path(out_str)
+    assert out.exists()
+    with fitz.open(str(out)) as result:
+        assert len(result) == 4
+        assert len(result[0].get_images(full=True)) == page1_images_before + 1
+
+
+def test_sign_pdf_rejects_bad_page(sample_pdf, signature_png, tmp_path):
+    with pytest.raises(ValueError):
+        sign_pdf(str(sample_pdf), str(signature_png), str(tmp_path), page=99)
+
+
+def test_sign_pdf_rejects_missing_signature(sample_pdf, tmp_path):
+    with pytest.raises(ValueError):
+        sign_pdf(str(sample_pdf), str(tmp_path / "nope.png"), str(tmp_path))


### PR DESCRIPTION
## Summary

Adds a large batch of file-conversion features modeled on Adobe Acrobat / iLovePDF paid tiers, builds two brand-new tool pages (Excel and PPT), and wires every new operation into the Workflow builder.

### PDF (4 new + polish)
- **Merge PDFs**, **Add Watermark**, **PDF → JPG/PNG (zip)**, **Sign PDF** (signature image stamped at chosen page/position).
- `pdf_to_docx` now runs in a threadpool with `multi_processing=True` (auto-fallback) so large conversions don't block the event loop.

### Image (4 new)
- **Rotate** (90/180/270°), **Compress** (quality slider), **Convert format** (JPG ↔ PNG ↔ WebP), **Add Watermark** (position + opacity + color).
- Image input now accepts any common image type, not just HEIC.

### Excel (brand-new page)
- **Excel → PDF**, **CSV → XLSX**, **XLSX → CSV**, **Merge workbooks**.
- Pure-Python via `openpyxl` + `pandas` + `reportlab`.

### PPT (brand-new page)
- **PPT → PDF**, **PPT → Images (zip)**, **Merge PPTX**.
- Pure-Python via `python-pptx` + `Pillow` + `reportlab`.

### Workflow
- 10 new draggable step types added to the palette, each with a config modal:
  rotate_image, compress_image, convert_image, watermark_image,
  excel_to_pdf, csv_to_xlsx, xlsx_to_csv, ppt_to_pdf, ppt_to_images,
  plus the existing surface area.

## Caveats reviewers should know

- **Excel → PDF** and **PPT → PDF** use a pure-Python pipeline by design (per scoping discussion). Cell colors, merged cells, and charts (Excel) and animations, gradients, SmartArt (PPT) are approximated or dropped. Pixel-exact rendering would require LibreOffice on the host (\`soffice --headless --convert-to pdf\`).
- New Python deps: \`openpyxl\`, \`pandas\`, \`python-pptx\` (added to \`requirements.txt\`).

## Files

- Backend: \`main.py\` (15 new routes + workflow executor), \`scripts/pdf_utils.py\`, \`scripts/image_utils.py\`, \`scripts/excel_utils.py\` (new), \`scripts/ppt_utils.py\` (new).
- Frontend: \`static/index.html\`, \`static/script.js\`.
- Tests: \`tests/test_pdf_new_features.py\` (new, 10), \`tests/test_new_image_excel_ppt.py\` (new, 20).

## Test plan

- [ ] \`pip install -r requirements.txt\` (openpyxl, pandas, python-pptx are the new deps)
- [ ] \`pytest tests/test_pdf_new_features.py tests/test_new_image_excel_ppt.py\` — all 30 new tests should pass
- [ ] \`pytest tests/test_pdf_utils.py tests/test_image_utils.py tests/test_image_resize.py tests/test_image_crop.py\` — existing tests should still pass
- [ ] \`uvicorn main:app --reload\` and smoke each new card on the PDF, Image, Excel, and PPT pages
- [ ] Build a Workflow chaining a couple of new steps (e.g. CSV → XLSX → Excel → PDF) and verify SSE progress events fire for each

🤖 Generated with [Claude Code](https://claude.com/claude-code)