### PR TITLE
Fix pdf utils startup fragility and Paddle models path resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,14 @@
 
 > **CRITICAL**: Add entry here BEFORE every commit.
 
+### 2026-05-16
+
+- **fix**: Removed import-time hard dependencies in `scripts/pdf_utils.py` by deferring heavy libraries (`pdf2docx`, `PyMuPDF`, `OpenCV`, `python-docx`) to function scope, so app/module import no longer crashes when optional native libs are unavailable.
+- **fix**: Corrected Paddle model directory resolution to use repository-level `models/` as fallback when `scripts/models/` is absent.
+- **test**: Added resilience tests covering optional-dependency import behavior and models path resolution logic.
+- **Files**: `scripts/pdf_utils.py`, `tests/test_pdf_utils_import_resilience.py`, `AGENTS.md`
+- **Verification**: `PYTHONPATH=. pytest -q tests/test_pdf_utils_import_resilience.py` passed.
+
 ### 2026-04-21
 
 - **feat**: Automatically delete files in `/outputs` after downloading to save disk space

--- a/scripts/pdf_utils.py
+++ b/scripts/pdf_utils.py
@@ -2,7 +2,6 @@ import threading
 import uuid
 import pikepdf
 from pathlib import Path
-from pdf2docx import Converter
 import os
 from typing import List
 
@@ -15,17 +14,22 @@ os.environ['FLAGS_enable_mkldnn'] = '0'
 # Force CPU-only mode with basic backend
 os.environ['CUDA_VISIBLE_DEVICES'] = ''
 
-import fitz
-import cv2
-import numpy as np
-from docxcompose.composer import Composer
-from docx import Document as Document_docx
 import shutil
 
 
 # Global cache for PaddleOCR engine to avoid expensive re-initialization
 _PADDLE_ENGINE = None
 _ENGINE_LOCK = threading.Lock()
+
+
+def _resolve_models_dir() -> Path:
+    """Resolve the Paddle models directory from common project layouts."""
+    script_dir = Path(__file__).resolve().parent
+    candidates = [script_dir / "models", script_dir.parent / "models"]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[1]
 
 def get_paddle_engine():
     """Returns cached PaddleOCR engine instance, initializing if needed (thread-safe)."""
@@ -41,8 +45,7 @@ def get_paddle_engine():
                     print(f"[AI] Error: PaddleOCR not installed correctly. {e}")
                     raise ImportError("PaddleOCR engine is missing. If you are on the Free Tier, it might have failed to install due to size limits.")
 
-                base_dir = Path(__file__).parent
-                paddle_dir = base_dir / "models"
+                paddle_dir = _resolve_models_dir()
                 layout_dir = paddle_dir / "layout" / "picodet_lcnet_x1_0_fgd_layout_infer"
                 table_dir = paddle_dir / "table" / "en_ppstructure_mobile_v2.0_SLANet_inference"
                 det_dir = paddle_dir / "det" / "en" / "en_PP-OCRv3_det_infer"
@@ -189,6 +192,7 @@ def compress_pdf(input_path: str, output_dir: str, level: str = 'medium', passwo
     Returns dict with output_path, original_size, compressed_size, reduction_pct.
     """
     import io
+    import fitz
     from PIL import Image as PILImage
 
     input_file = Path(input_path)
@@ -270,6 +274,8 @@ def compress_pdf(input_path: str, output_dir: str, level: str = 'medium', passwo
 
 def pdf_to_docx(input_path: str, output_dir: str, password: str = None) -> str:
     """Converts PDF to DOCX using pdf2docx (Fast, Rule-based)."""
+    from pdf2docx import Converter
+
     input_file = Path(input_path)
     output_file = Path(output_dir) / f"{input_file.stem}.docx"
 
@@ -332,6 +338,8 @@ def add_watermark(
     password: str = None,
 ) -> str:
     """Stamp a text watermark on every page."""
+    import fitz
+
     if not text or not text.strip():
         raise ValueError("Watermark text cannot be empty.")
     try:
@@ -408,6 +416,7 @@ def pdf_to_images_zip(
 ) -> dict:
     """Render every PDF page to an image and return a zip."""
     import zipfile
+    import fitz
 
     try:
         dpi = int(dpi)
@@ -463,6 +472,8 @@ def sign_pdf(
     x, y, width are normalized (0-1) relative to page size. (x, y) is the top-left
     of the signature box.
     """
+    import fitz
+
     try:
         page = int(page)
         x = float(x)
@@ -521,6 +532,9 @@ def sign_pdf(
 
 def merge_docx_files(input_files: list, output_file: str) -> None:
     """Merges multiple DOCX files into one, inserting page breaks between them."""
+    from docxcompose.composer import Composer
+    from docx import Document as Document_docx
+
     if not input_files:
         raise ValueError("No input files provided for merging.")
 
@@ -535,6 +549,10 @@ def merge_docx_files(input_files: list, output_file: str) -> None:
 
 def pdf_to_word_paddle(input_path: str, output_dir: str, password: str = None) -> str:
     """Converts PDF to DOCX using PaddleOCR Layout Recovery (Slow, AI-based)."""
+    import cv2
+    import fitz
+    import numpy as np
+
     # Deferred imports for utility functions that depend on paddleocr
     try:
         from paddleocr import save_structure_res

--- a/tests/test_pdf_utils_import_resilience.py
+++ b/tests/test_pdf_utils_import_resilience.py
@@ -1,0 +1,32 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def test_pdf_utils_import_without_optional_dependencies(monkeypatch):
+    """Module import should succeed even if heavy optional deps are unavailable."""
+    real_import = __import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name in {"cv2", "pdf2docx", "fitz", "docxcompose", "docx"}:
+            raise ImportError(f"simulated missing optional dependency: {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", guarded_import)
+    sys.modules.pop("scripts.pdf_utils", None)
+
+    module = importlib.import_module("scripts.pdf_utils")
+
+    assert hasattr(module, "remove_pdf_password")
+    assert hasattr(module, "pdf_to_docx")
+
+
+def test_resolve_models_dir_prefers_repo_models(monkeypatch):
+    module = importlib.import_module("scripts.pdf_utils")
+    fake_script = Path("/tmp/project/scripts/pdf_utils.py")
+    monkeypatch.setattr(module, "__file__", str(fake_script))
+
+    resolved = module._resolve_models_dir()
+    assert str(resolved).endswith("/tmp/project/models")


### PR DESCRIPTION
### Motivation
- Importing `scripts/pdf_utils.py` could crash app startup in environments missing native-heavy optional libraries (`pdf2docx`, `PyMuPDF/fitz`, `OpenCV/cv2`, `python-docx`), preventing test boots and deployments.
- Paddle model lookup assumed `scripts/models/` and failed when the repo-level `models/` layout was used, causing engine initialization errors.

### Description
- Deferred heavy optional imports into the functions that need them inside `scripts/pdf_utils.py` so the module can be imported even when native dependencies are absent. 
- Added `_resolve_models_dir()` and switched `get_paddle_engine()` to use it so model lookup prefers `scripts/models/` and falls back to the repository `models/` path. 
- Added focused unit tests in `tests/test_pdf_utils_import_resilience.py` to verify import resilience and models directory resolution. 
- Updated `AGENTS.md` changelog entry to record fixes and the new tests.

### Testing
- Ran the focused regression tests with `PYTHONPATH=. pytest -q tests/test_pdf_utils_import_resilience.py` which passed (2 tests). 
- Attempting the full test run earlier showed environment/import problems (e.g., missing `main` import / native `cv2` libs) that are unrelated to the targeted fixes and remain outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0803658f88833196d7b9dac8b0ddda)